### PR TITLE
Prioritize matching scoped prefixes for command resolution

### DIFF
--- a/core/prefix.py
+++ b/core/prefix.py
@@ -1,7 +1,7 @@
 """Prefix helpers for the C1C Achievements bot."""
 from __future__ import annotations
 
-from typing import Any, Sequence, Tuple
+from typing import Any, List, Sequence, Tuple
 
 SCOPED_PREFIXES: Tuple[str, ...] = ("!sc", "!rem", "!wc", "!mm")
 GLOBAL_PREFIX: str = "!"
@@ -14,9 +14,18 @@ PREFIX_LABELS = {
 }
 
 
-def get_prefix(_bot: Any, _message: Any) -> Sequence[str]:
+def get_prefix(_bot: Any, message: Any) -> Sequence[str]:
     """Return the runtime prefix list for discord.py."""
-    return ALL_PREFIXES
+
+    content = getattr(message, "content", "") or ""
+    matched_prefixes: List[str] = [
+        prefix for prefix in SCOPED_PREFIXES if content.startswith(prefix)
+    ]
+    remaining_prefixes: List[str] = [
+        prefix for prefix in SCOPED_PREFIXES if prefix not in matched_prefixes
+    ]
+
+    return [*matched_prefixes, *remaining_prefixes, GLOBAL_PREFIX]
 
 
 def is_scoped_prefix(prefix: str) -> bool:


### PR DESCRIPTION
## Summary
- prioritize scoped prefixes that match a message's content when building the runtime prefix list
- keep remaining scoped prefixes and the global fallback available for help text and legacy commands

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ded9eb64148323a28c952c09ef3d6f