### PR TITLE
Enable stripping spaces after command prefixes

### DIFF
--- a/c1c_claims_appreciation.py
+++ b/c1c_claims_appreciation.py
@@ -98,7 +98,8 @@ intents = discord.Intents.default()
 intents.message_content = True
 intents.members = True
 intents.guilds = True
-bot = commands.Bot(command_prefix=get_prefix, intents=intents)
+bot = commands.Bot(command_prefix=get_prefix, intents=intents, strip_after_prefix=True)
+# Ensure prefixes like "!sc" accept a space-separated command (e.g., "!sc health").
 
 # disable default help so we can own !help behavior
 try:


### PR DESCRIPTION
## Summary
- configure the Discord bot to strip whitespace after prefixes so scoped commands like `!sc health` parse correctly
- document the need for the setting inline for future maintainers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dedf2fbee48323aa641325057c8460