### PR TITLE
Improve shard OCR accuracy and fallback

### DIFF
--- a/cogs/shards/ocr.py
+++ b/cogs/shards/ocr.py
@@ -8,25 +8,36 @@ from .constants import ShardType
 # Accept "1,610" / "1.610" / "1 610" etc.
 _NUM_RE = re.compile(r"^\d{1,4}(?:[.,\s]\d{3})*$")
 
+
 def _normalize_digits(s: str) -> str:
     # fix common OCR slips: l/İ/I → 1, O/º → 0, stray spaces inside thousand groups
     tbl = str.maketrans({
         "l": "1", "I": "1", "İ": "1", "í": "1",
-        "O": "0", "o": "0", "º": "0"
+        "O": "0", "o": "0", "º": "0",
     })
     return (s or "").translate(tbl)
+
 
 _LABEL_TO_ST: Dict[str, ShardType] = {
     "mystery": ShardType.MYSTERY,
     "ancient": ShardType.ANCIENT,
-    "void":    ShardType.VOID,
-    "primal":  ShardType.PRIMAL,
-    "sacred":  ShardType.SACRED,
+    "void": ShardType.VOID,
+    "primal": ShardType.PRIMAL,
+    "sacred": ShardType.SACRED,
 }
+
+
+def _label_key(raw: str) -> Optional[str]:
+    cleaned = re.sub(r"[^a-z]", "", (raw or "").lower())
+    if cleaned.endswith("shard"):
+        cleaned = cleaned[:-5]
+    return cleaned if cleaned in _LABEL_TO_ST else None
+
 
 def _to_int(num_text: str) -> int:
     s = _normalize_digits(num_text).replace(",", "").replace(".", "").replace(" ", "")
     return int(s) if s.isdigit() else 0
+
 
 def _scale_if_small(w: int, h: int) -> float:
     # Small mobile screenshots benefit from a 1.5–2.0x scale before OCR.
@@ -36,10 +47,12 @@ def _scale_if_small(w: int, h: int) -> float:
         return 1.5
     return 1.0
 
+
 def extract_counts_from_image_bytes(data: bytes) -> Dict[ShardType, int]:
-    """
-    Returns {ShardType: int} by reading the LEFT shard list.
-    Two-pass approach:
+    """OCR shard counts from a screenshot.
+
+    Returns {ShardType: int} by reading the shard list rail. The OCR work happens
+    in two passes:
       • Pass A (labels): full image, psm 6 — find 'Mystery/Ancient/Void/Primal/Sacred'
       • Pass B (numbers): left-rail ROI, grayscale+threshold, digit whitelist — find counts
     """
@@ -65,7 +78,6 @@ def extract_counts_from_image_bytes(data: bytes) -> Dict[ShardType, int]:
         # -------------------------
         # PASS A: LABELS (words)
         # -------------------------
-        # Use a gentle enhance to help word shapes.
         lab_img = ImageOps.autocontrast(base)
         lab_cfg = "--oem 3 --psm 6"
         lab = pytesseract.image_to_data(lab_img, output_type=Output.DICT, config=lab_cfg)
@@ -81,42 +93,62 @@ def extract_counts_from_image_bytes(data: bytes) -> Dict[ShardType, int]:
                 conf = -1.0
             if conf < 35:
                 continue
-            x = int(lab["left"][i]); y = int(lab["top"][i])
-            w = int(lab["width"][i]); h = int(lab["height"][i])
-            words.append({"t": t, "x": x, "y": y, "w": w, "h": h, "cx": x + w / 2, "cy": y + h / 2, "conf": conf})
+            x = int(lab["left"][i])
+            y = int(lab["top"][i])
+            w = int(lab["width"][i])
+            h = int(lab["height"][i])
+            words.append({
+                "t": t,
+                "x": x,
+                "y": y,
+                "w": w,
+                "h": h,
+                "cx": x + w / 2,
+                "cy": y + h / 2,
+                "conf": conf,
+            })
 
         if not words:
             return {}
 
-        labels = [w for w in words if w["t"].lower() in _LABEL_TO_ST]
-        if not labels:
-            # occasionally Tesseract sees "Mystery Shard" as one token; split crude heuristic
-            for w in words:
-                lw = w["t"].lower()
-                if lw.endswith("shard"):
-                    head = lw.replace(" shard", "")
-                    if head in _LABEL_TO_ST:
-                        labels.append({**w, "t": head})
+        cand_labels = []
+        for w in words:
+            key = _label_key(w["t"])
+            if not key:
+                continue
+            cand_labels.append({**w, "label": key})
+
+        if not cand_labels:
+            return {}
+
+        labels_by_type: Dict[ShardType, Dict[str, object]] = {}
+        for lab in cand_labels:
+            st = _LABEL_TO_ST[lab["label"]]
+            prev = labels_by_type.get(st)
+            if not prev or lab["conf"] > prev["conf"]:
+                labels_by_type[st] = lab
+
+        labels = list(labels_by_type.values())
         if not labels:
             return {}
 
         # -------------------------
         # PASS B: NUMBERS (left rail ROI)
         # -------------------------
-        # The shard list sits on the left ~35–45% of the screen across devices.
-        roi_x2 = int(W * 0.45)
-        roi = base.crop((0, 0, roi_x2, H))  # left rail
-        # convert to grayscale + autocontrast + slight sharpen + binary threshold
+        max_label_edge = max(lab["x"] + lab["w"] for lab in labels)
+        roi_x2 = min(W, int(max(W * 0.6, max_label_edge + W * 0.2)))
+        roi = base.crop((0, 0, roi_x2, H))
+
         num_img = ImageOps.grayscale(roi)
         num_img = ImageOps.autocontrast(num_img)
         num_img = num_img.filter(ImageFilter.UnsharpMask(radius=1.0, percent=120, threshold=3))
-        # hard threshold to make digits crisp; 160 is a good mid-point for these UIs
         num_img = num_img.point(lambda p: 255 if p > 160 else 0)
 
         num_cfg = (
             "--oem 3 --psm 6 "
             "-c tessedit_char_whitelist=0123456789., "
-            "-c preserve_interword_spaces=1"
+            "-c preserve_interword_spaces=1 "
+            "-c classify_bln_numeric_mode=1"
         )
         nd = pytesseract.image_to_data(num_img, output_type=Output.DICT, config=num_cfg)
 
@@ -126,7 +158,6 @@ def extract_counts_from_image_bytes(data: bytes) -> Dict[ShardType, int]:
             if not raw:
                 continue
             t = _normalize_digits(raw)
-            # re-add spaces check by normalizing for the regex
             t_for_match = t.replace("\u00A0", " ")  # non-breaking space
             if not (_NUM_RE.match(t_for_match) or t_for_match.isdigit()):
                 continue
@@ -136,151 +167,57 @@ def extract_counts_from_image_bytes(data: bytes) -> Dict[ShardType, int]:
                 conf = -1.0
             if conf < 30:
                 continue
-            x = int(nd["left"][i]); y = int(nd["top"][i])
-            w = int(nd["width"][i]); h = int(nd["height"][i])
-            # map ROI coords back to full image space for band math
-            cx = x + w / 2
-            cy = y + h / 2
-            nums.append({"t": t, "x": x, "y": y, "w": w, "h": h, "cx": cx, "cy": cy, "conf": conf})
+            x = int(nd["left"][i])
+            y = int(nd["top"][i])
+            w = int(nd["width"][i])
+            h = int(nd["height"][i])
+            nums.append({
+                "t": t,
+                "x": x,
+                "y": y,
+                "w": w,
+                "h": h,
+                "cx": x + w / 2,
+                "cy": y + h / 2,
+                "conf": conf,
+            })
 
         if not nums:
             return {}
 
         # -------------------------
-        # MATCH: per label, pick best number LEFT of label in same band
+        # MATCH labels to numbers (allow left OR right of label)
         # -------------------------
         results: Dict[ShardType, int] = {}
         for lab in labels:
-            st = _LABEL_TO_ST[lab["t"].lower()]
-            # Horizontal band around the label row
-            band_top = lab["cy"] - max(22, lab["h"] * 1.1)
-            band_bot = lab["cy"] + max(22, lab["h"] * 1.1)
+            st = _LABEL_TO_ST[lab["label"]]
+            band_top = lab["cy"] - max(22, lab["h"] * 1.2)
+            band_bot = lab["cy"] + max(22, lab["h"] * 1.2)
 
-            cands = [n for n in nums if (band_top <= n["cy"] <= band_bot) and (n["cx"] < lab["x"])]
+            cands = [n for n in nums if band_top <= n["cy"] <= band_bot]
             if not cands:
-                # wider tolerance if label/number heights differ (different DPIs)
-                cands = [n for n in nums if (abs(n["cy"] - lab["cy"]) <= max(30, lab["h"] * 1.5)) and (n["cx"] < lab["x"])]
+                cands = [n for n in nums if abs(n["cy"] - lab["cy"]) <= max(32, lab["h"] * 1.6)]
             if not cands:
                 continue
 
-            # closest by X (to the left) with small confidence bonus
-            def score(nw):
-                dx = lab["x"] - nw["cx"]
-                return dx - (nw["conf"] * 0.4)  # lower better
+            anchor_x = lab["x"] + (lab["w"] / 2)
+            max_dx = max(lab["w"] * 6, W * 0.28)
+            cands = [n for n in cands if abs(n["cx"] - anchor_x) <= max_dx]
+            if not cands:
+                continue
+
+            def score(nw: Dict[str, float]) -> float:
+                dx = abs(nw["cx"] - anchor_x)
+                return dx - (nw["conf"] * 0.4)  # lower is better
 
             best = min(cands, key=score)
             results[st] = max(results.get(st, 0), _to_int(best["t"]))
 
-        return results
-    except Exception:
-        return {}
+        if not results:
+            return {}
 
-        # Build quick lookups
-        labels = [w for w in words if w["t"].lower() in _LABEL_TO_ST]
-        numbers = [w for w in words if _NUM_RE.match(w["t"])]
-
-        # If Tesseract split "Mystery" and "Shard", that's OK—we match the 'Mystery' token only.
-        # For each label, pick the best number to its LEFT in the same horizontal band.
-        results: Dict[ShardType, int] = {}
-        for lab in labels:
-            st = _LABEL_TO_ST[lab["t"].lower()]
-            band_top = lab["cy"] - max(18, lab["h"] * 0.9)
-            band_bot = lab["cy"] + max(18, lab["h"] * 0.9)
-
-            # candidates left of the label, within band
-            cands = [
-                num for num in numbers
-                if (band_top <= num["cy"] <= band_bot) and (num["cx"] < lab["x"])
-            ]
-            if not cands:
-                # fallback: small drift tolerance
-                cands = [
-                    num for num in numbers
-                    if (abs(num["cy"] - lab["cy"]) <= max(24, lab["h"])) and (num["cx"] < lab["x"])
-                ]
-            if not cands:
-                continue
-
-            # choose the closest on X (to the left) with a small bonus for higher conf
-            def score(nw):
-                dx = (lab["x"] - nw["cx"])
-                return (dx) - (nw["conf"] * 0.5)  # lower is better
-            best = min(cands, key=score)
-            results[st] = max(results.get(st, 0), _to_int(best["t"]))
-
-        return results
-    except Exception:
-        return {}
-
-        # Build quick lookups
-        labels = [w for w in words if w["t"].lower() in _LABEL_TO_ST]
-        numbers = [w for w in words if _NUM_RE.match(w["t"])]
-
-        # If Tesseract split "Mystery" and "Shard", that's OK—we match the 'Mystery' token only.
-        # For each label, pick the best number to its LEFT in the same horizontal band.
-        results: Dict[ShardType, int] = {}
-        for lab in labels:
-            st = _LABEL_TO_ST[lab["t"].lower()]
-            band_top = lab["cy"] - max(18, lab["h"] * 0.9)
-            band_bot = lab["cy"] + max(18, lab["h"] * 0.9)
-
-            # candidates left of the label, within band
-            cands = [
-                num for num in numbers
-                if (band_top <= num["cy"] <= band_bot) and (num["cx"] < lab["x"])
-            ]
-            if not cands:
-                # fallback: small drift tolerance
-                cands = [
-                    num for num in numbers
-                    if (abs(num["cy"] - lab["cy"]) <= max(24, lab["h"])) and (num["cx"] < lab["x"])
-                ]
-            if not cands:
-                continue
-
-            # choose the closest on X (to the left) with a small bonus for higher conf
-            def score(nw):
-                dx = (lab["x"] - nw["cx"])
-                return (dx) - (nw["conf"] * 0.5)  # lower is better
-            best = min(cands, key=score)
-            results[st] = max(results.get(st, 0), _to_int(best["t"]))
-
-        return results
-    except Exception:
-        return {}
-
-        # Build quick lookups
-        labels = [w for w in words if w["t"].lower() in _LABEL_TO_ST]
-        numbers = [w for w in words if _NUM_RE.match(w["t"])]
-
-        # If Tesseract split "Mystery" and "Shard", that's OK—we match the 'Mystery' token only.
-        # For each label, pick the best number to its LEFT in the same horizontal band.
-        results: Dict[ShardType, int] = {}
-        for lab in labels:
-            st = _LABEL_TO_ST[lab["t"].lower()]
-            band_top = lab["cy"] - max(18, lab["h"] * 0.9)
-            band_bot = lab["cy"] + max(18, lab["h"] * 0.9)
-
-            # candidates left of the label, within band
-            cands = [
-                num for num in numbers
-                if (band_top <= num["cy"] <= band_bot) and (num["cx"] < lab["x"])
-            ]
-            if not cands:
-                # fallback: small drift tolerance
-                cands = [
-                    num for num in numbers
-                    if (abs(num["cy"] - lab["cy"]) <= max(24, lab["h"])) and (num["cx"] < lab["x"])
-                ]
-            if not cands:
-                continue
-
-            # choose the closest on X (to the left) with a small bonus for higher conf
-            def score(nw):
-                dx = (lab["x"] - nw["cx"])
-                return (dx) - (nw["conf"] * 0.5)  # lower is better
-            best = min(cands, key=score)
-            results[st] = max(results.get(st, 0), _to_int(best["t"]))
+        for st in ShardType:
+            results.setdefault(st, 0)
 
         return results
     except Exception:

--- a/cogs/shards/sheets_adapter.py
+++ b/cogs/shards/sheets_adapter.py
@@ -260,20 +260,22 @@ def upsert_state(discord_id: int, clan_tag: str, *,
         ws.append_row(payload, value_input_option="RAW")
 
 # Optional helper for prefill UIs (safe to leave unused)
-def get_last_inventory(discord_id: int) -> Optional[Dict[ShardType, int]]:
+def get_last_inventory(discord_id: int, clan_tag: Optional[str] = None) -> Optional[Dict[ShardType, int]]:
     try:
         ws = _ws_required("SHARD_SNAPSHOTS")
         rows = ws.get_all_records()
         rows = [r for r in rows if str(r.get("discord_id")) == str(discord_id)]
+        if clan_tag:
+            rows = [r for r in rows if str(r.get("clan_tag")) == str(clan_tag)]
         if not rows:
             return None
         r = rows[-1]
         return {
-            ShardType.MYSTERY: int(r.get("mystery", 0)),
-            ShardType.ANCIENT: int(r.get("ancient", 0)),
-            ShardType.VOID:    int(r.get("void", 0)),
-            ShardType.SACRED:  int(r.get("sacred", 0)),
-            ShardType.PRIMAL:  int(r.get("primal", 0)),
+            ShardType.MYSTERY: _toi(r.get("mystery", 0)),
+            ShardType.ANCIENT: _toi(r.get("ancient", 0)),
+            ShardType.VOID:    _toi(r.get("void", 0)),
+            ShardType.SACRED:  _toi(r.get("sacred", 0)),
+            ShardType.PRIMAL:  _toi(r.get("primal", 0)),
         }
     except Exception:
         return None


### PR DESCRIPTION
## Summary
- improve shard OCR preprocessing, label parsing, and number matching so all five shard counts are captured more reliably
- fall back to the user+clan snapshot from Sheets when OCR returns no counts before opening the modal
- extend the Sheets adapter helper so it can fetch the latest snapshot for a specific clan

## Testing
- python -m compileall cogs/shards

------
https://chatgpt.com/codex/tasks/task_e_68dfb54c20b88323b44f62bdab78943c