### PR TITLE
Handle plural shard labels in OCR

### DIFF
--- a/cogs/shards/ocr.py
+++ b/cogs/shards/ocr.py
@@ -29,8 +29,12 @@ _LABEL_TO_ST: Dict[str, ShardType] = {
 
 def _label_key(raw: str) -> Optional[str]:
     cleaned = re.sub(r"[^a-z]", "", (raw or "").lower())
-    if cleaned.endswith("shard"):
+    if cleaned.endswith("shards"):
+        cleaned = cleaned[:-6]
+    elif cleaned.endswith("shard"):
         cleaned = cleaned[:-5]
+    if cleaned.endswith("s"):
+        cleaned = cleaned[:-1]
     return cleaned if cleaned in _LABEL_TO_ST else None
 
 


### PR DESCRIPTION
## Summary
- update shard label normalization to drop both `shard`/`shards` suffixes and leftover plurals before lookup
- keep the OCR pipeline otherwise unchanged while ensuring plural labels resolve to shard types

## Testing
- python - <<'PY'
import importlib.util, pathlib, sys, types
pkg = types.ModuleType('cogs')
pkg.__path__ = [str(pathlib.Path('cogs'))]
sys.modules['cogs'] = pkg
subpkg = types.ModuleType('cogs.shards')
subpkg.__path__ = [str(pathlib.Path('cogs/shards'))]
sys.modules['cogs.shards'] = subpkg
spec = importlib.util.spec_from_file_location('cogs.shards.constants', pathlib.Path('cogs/shards/constants.py'))
const_mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(const_mod)
sys.modules['cogs.shards.constants'] = const_mod
spec = importlib.util.spec_from_file_location('cogs.shards.ocr', pathlib.Path('cogs/shards/ocr.py'))
ocr = importlib.util.module_from_spec(spec)
spec.loader.exec_module(ocr)
samples = ["Mystery Shards", "Void Shards", "Ancient Shard", "Sacred shards", "Primal shardS", "mystery"]
for s in samples:
    print(s, '->', ocr._label_key(s))
print('Resolved types:', {s: ocr._LABEL_TO_ST[ocr._label_key(s)] for s in samples if ocr._label_key(s)})
PY

------
https://chatgpt.com/codex/tasks/task_e_68dfc6d4b184832391608118bd9b1ac6