### PR TITLE
Handle redundant trailing s characters in shard OCR labels

### DIFF
--- a/cogs/shards/ocr.py
+++ b/cogs/shards/ocr.py
@@ -29,12 +29,10 @@ _LABEL_TO_ST: Dict[str, ShardType] = {
 
 def _label_key(raw: str) -> Optional[str]:
     cleaned = re.sub(r"[^a-z]", "", (raw or "").lower())
-    if cleaned.endswith("shards"):
-        cleaned = cleaned[:-6]
-    elif cleaned.endswith("shard"):
+    cleaned = cleaned.rstrip("s")
+    if cleaned.endswith("shard"):
         cleaned = cleaned[:-5]
-    if cleaned.endswith("s"):
-        cleaned = cleaned[:-1]
+        cleaned = cleaned.rstrip("s")
     return cleaned if cleaned in _LABEL_TO_ST else None
 
 

--- a/tests/test_ocr_label_key.py
+++ b/tests/test_ocr_label_key.py
@@ -1,0 +1,40 @@
+import importlib
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+if "cogs" not in sys.modules:
+    cogs_pkg = types.ModuleType("cogs")
+    cogs_pkg.__path__ = [str(ROOT / "cogs")]
+    sys.modules["cogs"] = cogs_pkg
+
+if "cogs.shards" not in sys.modules:
+    shards_pkg = types.ModuleType("cogs.shards")
+    shards_pkg.__path__ = [str(ROOT / "cogs" / "shards")]
+    sys.modules["cogs.shards"] = shards_pkg
+
+constants = importlib.import_module("cogs.shards.constants")
+ocr = importlib.import_module("cogs.shards.ocr")
+
+ShardType = constants.ShardType
+_LABEL_TO_ST = ocr._LABEL_TO_ST
+_label_key = ocr._label_key
+
+
+@pytest.mark.parametrize(
+    "label, expected",
+    [
+        ("Void Shardss", ShardType.VOID),
+        ("Ancients", ShardType.ANCIENT),
+        ("Mystery Shards", ShardType.MYSTERY),
+        ("Sacredss", ShardType.SACRED),
+    ],
+)
+def test_label_key_handles_extra_s(label: str, expected: ShardType) -> None:
+    key = _label_key(label)
+    assert key is not None
+    assert _LABEL_TO_ST[key] == expected


### PR DESCRIPTION
## Summary
- ensure shard label normalization strips redundant trailing "s" characters before removing the "shard" suffix so duplicate trailing letters still resolve to known shard types
- add pytest coverage that exercises label samples with extra trailing "s" characters to confirm correct ShardType mapping

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfc9506aa88323ab27373e289c741e