### PR TITLE
Fix shard OCR label suffix stripping

### DIFF
--- a/cogs/shards/ocr.py
+++ b/cogs/shards/ocr.py
@@ -29,10 +29,11 @@ _LABEL_TO_ST: Dict[str, ShardType] = {
 
 def _label_key(raw: str) -> Optional[str]:
     cleaned = re.sub(r"[^a-z]", "", (raw or "").lower())
+    for suffix in ("shards", "shard"):
+        if cleaned.endswith(suffix):
+            cleaned = cleaned[: -len(suffix)]
+            break
     cleaned = cleaned.rstrip("s")
-    if cleaned.endswith("shard"):
-        cleaned = cleaned[:-5]
-        cleaned = cleaned.rstrip("s")
     return cleaned if cleaned in _LABEL_TO_ST else None
 
 


### PR DESCRIPTION
## Summary
- update shard label normalization to strip both "shards" and "shard" suffixes before lookup
- ensure residual plural "s" characters are removed after trimming suffixes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfccdff6bc8323aa0d490dd4f1c3fb