### PR TITLE
Adjust OCR crop ratios to restore wide rail coverage

### DIFF
--- a/cogs/shards/ocr.py
+++ b/cogs/shards/ocr.py
@@ -91,7 +91,7 @@ def extract_counts_from_image_bytes(data: bytes) -> Dict[ShardType, int]:
             base = base.resize((int(base.width * scale), int(base.height * scale)))
 
         # Try a few crop widths; pick the one that yields the most non-zero bands
-        ratios = (0.38, 0.36, 0.46)
+        ratios = (0.38, 0.42, 0.46)
         best_counts: Dict[ShardType, int] = {}
         best_score = -1
 
@@ -132,7 +132,7 @@ def extract_counts_with_debug(
         if scale != 1.0:
             base = base.resize((int(base.width * scale), int(base.height * scale)))
 
-        ratios = (0.42, 0.36, 0.46)
+        ratios = (0.38, 0.42, 0.46)
 
         # Build debug for the first ratio
         roi0 = _left_rail_crop(base, ratios[0])


### PR DESCRIPTION
## Summary
- update the primary OCR crop ratios to include the wider left-rail region again
- align debug exports with the preferred ratio so captured ROI matches the scorer

## Testing
- python - <<'PY'
import importlib.util, sys, types
cogs_mod = types.ModuleType('cogs')
shards_mod = types.ModuleType('cogs.shards')
shards_mod.__path__ = ['cogs/shards']
setattr(cogs_mod, 'shards', shards_mod)
sys.modules['cogs'] = cogs_mod
sys.modules['cogs.shards'] = shards_mod
spec = importlib.util.spec_from_file_location('cogs.shards.ocr', 'cogs/shards/ocr.py')
ocr = importlib.util.module_from_spec(spec)
spec.loader.exec_module(ocr)
ok, text = ocr.ocr_smoke_test()
print('ok:', ok)
print('text:', text)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e1443f1ce48323807c3010c7893b74