### PR TITLE
Add shard module reality-check artifacts and planning outputs

### DIFF
--- a/EMOJI_AUDIT.md
+++ b/EMOJI_AUDIT.md
@@ -1,0 +1,32 @@
+# Shard Emoji Usage Audit
+
+| Location | Purpose | Current Source | Custom emoji? | Notes |
+| --- | --- | --- | --- | --- |
+| `ShardsConfig.emoji` map from Sheets【F:cogs/shards/sheets_adapter.py†L91-L99】 | Persist configured shard emoji strings | Google Sheet columns `emoji_*`, defaulting to colored squares | ✅ if sheet stores `<:name:id>` strings, but defaults fall back to unicode | Defaults violate the policy when the sheet is blank; needs enforced custom IDs. |
+| `ShardsCog._emoji_or_abbr` fallback map【F:cogs/shards/cog.py†L94-L115】 | Formats shard labels in OCR preview and elsewhere | `cfg.emoji` lookup by shorthand, else hardcoded colored-square text | ❌ uses unicode fallback (`🟩Myst`, etc.) | Replace with centralized mapping; drop text suffix once IDs return full emoji codes. |
+| `SetCountsModal` field labels【F:cogs/shards/views.py†L10-L23】 | Modal input labels for manual counts | Literal unicode squares in labels | ❌ | Should pull display emoji from shared mapping so modal mirrors server icons. |
+| `AddPullsStart` buttons (mercy flow)【F:cogs/shards/views.py†L34-L47】 | Buttons to pick shard type | Literal unicode squares in button labels | ❌ | Swap to centralized emoji helper. |
+| `!shards help` copy【F:cogs/shards/cog.py†L400-L407】 | Help text describing shards | Inline unicode squares | ❌ | Update copy to interpolate custom emoji names. |
+
+## Recommended central mapping
+- **File:** `assets/emojis/shards.json`
+```json
+{
+  "mystery": "<:mystery_shard:000000000000000000>",
+  "ancient": "<:ancient_shard:000000000000000000>",
+  "void": "<:void_shard:000000000000000000>",
+  "primal": "<:primal_shard:000000000000000000>",
+  "sacred": "<:sacred_shard:000000000000000000>"
+}
+```
+- **Access helper signature:**
+```python
+def get_shard_emoji(shard: ShardType, *, overrides: Mapping[ShardType, str] | None = None) -> str:
+    """Return the configured custom emoji for the shard, falling back to the JSON mapping."""
+```
+- **Call sites to update:**
+  1. `ShardsCog._emoji_or_abbr` → delete fallback text and delegate to `get_shard_emoji`.
+  2. `SetCountsModal` labels → format labels dynamically.
+  3. `AddPullsStart` buttons → use helper.
+  4. Any string literals referencing shard emoji (`!shards help`, summary renderer) → inject helper output.【F:cogs/shards/renderer.py†L11-L58】
+  5. Sheets config loader → validate/normalize IDs rather than unicode defaults.【F:cogs/shards/sheets_adapter.py†L91-L99】

--- a/ISSUE_AUDIT.md
+++ b/ISSUE_AUDIT.md
@@ -1,0 +1,11 @@
+# Issue Audit — Shard Module
+
+| Issue | Labels (relevant) | Checklist status | Delta |
+| --- | --- | --- | --- |
+| P1 — Shards summary header logic crashes on populated sheet【F:.github/issue-batches/issues.json†L29-L37】 | `area:shards` | ❌ | Has goal + acceptance criteria, but lacks explicit non-goals, Discord test steps, and rollout/toggle notes. |
+| P2 — Batch & retry shard writes to reduce quota pressure【F:.github/issue-batches/issues.json†L49-L57】 | `area:shards` | ❌ | Scope described, yet no acceptance breakdown beyond success metrics, no non-goals, no verification steps, and no rollout guidance. |
+| (Missing) Feature — Manual entry (Skip OCR) on first panel | — | ❌ | No open issue tracks this spec-mandated change; create a feature issue with goal, acceptance criteria, manual test steps, and rollout notes. |
+| (Missing) Feature — Centralize shard emojis as custom server icons | — | ❌ | No backlog item covers emoji migration; needs full issue with readiness checklist items. |
+| (Missing) Epic — OCR v2 enhancements | — | ❌ | Follow-on OCR improvements (token stitching, per-band tweaks, debug) are unspecified; should be grouped into a blocked epic with clarity on scope/non-goals. |
+
+**Summary:** No existing shard-module issues meet the readiness checklist; new feature/epic entries are required for the manual-first UX and emoji policy updates, and existing shard issues must be fleshed out with test plans, non-goals, and rollout notes.

--- a/PATCH_PLAN.md
+++ b/PATCH_PLAN.md
@@ -1,0 +1,60 @@
+# Patch Plan
+
+## 1. Manual entry (Skip OCR) button on first panel
+- **File:** `cogs/shards/cog.py`
+  - Introduce a reusable helper inside `on_message` to open the manual modal without OCR; reuse existing logic from the preview’s `manual_btn` callback.【F:cogs/shards/cog.py†L235-L259】
+  - Add a `manual_btn_public` button to the public view alongside Scan/Dismiss, wiring it to the helper and ensuring it is available even when the message lacks image attachments.【F:cogs/shards/cog.py†L159-L333】
+  - Adjust the attachment guard so shard-thread messages without images still post a manual-only prompt (or a prompt where Scan is disabled/hidden) to satisfy the spec.【F:cogs/shards/cog.py†L133-L166】
+  - Clear OCR cache only when OCR actually runs; the manual-first path should bypass cache touches entirely.
+
+```
+@@ async def on_message(...):
+-    if not (message.attachments and any(_is_image_attachment(a) for a in message.attachments)):
+-        return
++    images = [a for a in message.attachments if _is_image_attachment(a)] if message.attachments else []
++
++    def _eligible_for_scan() -> bool:
++        return bool(images)
++
++    view = discord.ui.View(timeout=300)
++    scan_btn = discord.ui.Button(..., disabled=not _eligible_for_scan())
++    manual_btn_public = discord.ui.Button(label="Manual entry (Skip OCR)", style=discord.ButtonStyle.secondary, ...)
++    dismiss_btn = discord.ui.Button(...)
++
++    async def _manual_first(inter: discord.Interaction):
++        if inter.user.id != message.author.id and not _has_any_role(...):
++            ...
++        await _open_manual_modal(inter, prefill=None)
++
++    manual_btn_public.callback = _manual_first
++    view.add_item(scan_btn)
++    view.add_item(manual_btn_public)
++    view.add_item(dismiss_btn)
+```
+
+- Share the modal-opening logic between `_manual_first` and the existing preview buttons to avoid duplication and keep validation consistent.
+
+## 2. Centralized shard emoji mapping
+- **Files:**
+  - `assets/emojis/shards.json` (new) — commit the canonical ID map referenced in the audit.【F:EMOJI_AUDIT.md†L15-L23】
+  - `cogs/shards/constants.py` or a new helper module (e.g. `cogs/shards/emoji.py`) — load the JSON at startup and expose `get_shard_emoji(shard, overrides=None)`.
+  - `cogs/shards/sheets_adapter.py` — replace unicode defaults with lookups against the JSON and validate that Sheet overrides are custom emoji strings (fallback to JSON if blank).【F:cogs/shards/sheets_adapter.py†L91-L99】
+  - `cogs/shards/cog.py` — replace `_emoji_or_abbr` with helper usage and update any string formatting that currently appends abbreviations.【F:cogs/shards/cog.py†L94-L124】【F:cogs/shards/cog.py†L400-L407】
+  - `cogs/shards/views.py` — compute modal labels and button text using the helper rather than hardcoded unicode.【F:cogs/shards/views.py†L10-L47】
+  - `cogs/shards/renderer.py` — swap to helper for summary embed formatting.【F:cogs/shards/renderer.py†L11-L58】
+
+```
++from .emoji import get_shard_emoji
+@@
+-def _fmt_counts_line(...):
+-    label = self._emoji_or_abbr(st)
++    label = get_shard_emoji(st, overrides=self.cfg.emoji)
+@@
+-class SetCountsModal(...):
+-    self.mys = discord.ui.TextInput(label="🟩 Mystery", ...)
++    mys_label = f"{get_shard_emoji(ShardType.MYSTERY, overrides=emoji_map)} Mystery"
++    self.mys = discord.ui.TextInput(label=mys_label, ...)
+```
+
+- Ensure the helper gracefully handles missing IDs (e.g. returns `<:placeholder:ID>` or a safe fallback) but log when defaults are used so staff can populate the mapping.
+- Update unit/integration docs (`README` / shard help copy) to reflect that custom emojis are enforced.

--- a/READY_TO_IMPLEMENT.md
+++ b/READY_TO_IMPLEMENT.md
@@ -1,0 +1,8 @@
+# Ready-to-Implement Gate
+
+**Status:** No
+
+**Blocking prerequisites:**
+1. Publish feature issues for the manual-first button and emoji migration with acceptance criteria, Discord test steps, non-goals, and rollout notes.【F:ISSUE_AUDIT.md†L5-L14】
+2. Decide on/collect the custom emoji IDs for each shard and commit the shared mapping file so engineering can wire it in without guessing.【F:EMOJI_AUDIT.md†L3-L24】
+3. Agree on the UX for manual entry when no attachment is present (public prompt copy, whether to show scan button disabled, etc.) before coding the listener change.【F:SPEC_DIFF.md†L11-L18】【F:UI_FLOW_MAP.md†L6-L13】

--- a/SHARDS_AUDIT.md
+++ b/SHARDS_AUDIT.md
@@ -1,0 +1,18 @@
+# Achievement Bot — Shard Module Reality Check
+
+## ✅ Verified against spec
+- OCR heavy work runs off-thread and the scan flow mirrors the documented defer → cache → preview pipeline.【F:cogs/shards/cog.py†L82-L305】
+- Cache keying, retry clearing, and the zero-result debug upload match the reference behavior.【F:cogs/shards/cog.py†L142-L278】
+- Diagnostic commands `!ocr info` / `!ocr selftest` remain intact for staff triage.【F:cogs/shards/cog.py†L345-L382】
+- OCR pipeline parameters (crop ratios, thresholding, OEM/PSM, confidence gate) align with the authoritative snapshot.【F:cogs/shards/ocr.py†L144-L405】
+
+## ❌ Gaps to address immediately
+1. **Manual-first path missing on first panel.** No button launches the manual modal until after OCR runs, and the listener bails out entirely when no screenshot is present.【F:cogs/shards/cog.py†L133-L333】
+2. **Emoji policy violations.** Multiple UI surfaces fall back to unicode squares instead of guaranteed custom emojis (config defaults, modal labels, mercy buttons, help text, renderer).【F:cogs/shards/cog.py†L94-L124】【F:cogs/shards/views.py†L10-L47】【F:cogs/shards/renderer.py†L11-L58】【F:cogs/shards/sheets_adapter.py†L91-L99】
+3. **Backlog readiness.** No feature/epic issues capture the mandated manual-first flow or emoji migration, and existing shard issues lack non-goals, test steps, and rollout notes.【F:ISSUE_AUDIT.md†L5-L14】
+
+## 🎯 Recommended next steps
+1. Ship the manual-first UX: add the “Manual entry (Skip OCR)” button to the public prompt, expose it even when no image is attached, and share modal-handling logic so both paths behave identically.【F:PATCH_PLAN.md†L3-L33】【F:UI_FLOW_MAP.md†L6-L23】
+2. Centralize shard emojis: commit the JSON mapping + helper, validate Sheet overrides, and swap all unicode placeholders to the custom set (preview, modals, embeds, help text).【F:EMOJI_AUDIT.md†L3-L24】【F:PATCH_PLAN.md†L35-L65】
+3. Refresh planning artifacts: adopt the new issue batch (milestone `Shard Module v0.4 — Manual First`) to track manual-first, emoji migration, and the deferred OCR epic.【F:issue-batches/shards-epic-refresh.json†L1-L69】
+4. Hold release until prerequisites in the ready-to-implement gate are met (issue hygiene, emoji IDs, UX decisions for no-attachment cases).【F:READY_TO_IMPLEMENT.md†L1-L8】

--- a/SPEC_DIFF.md
+++ b/SPEC_DIFF.md
@@ -1,0 +1,22 @@
+# Spec vs. Implementation — Shard Module
+
+## Interaction Flow
+- ✅ **Image watcher defers OCR work off the gateway loop.** `_ocr_prefill_from_attachment` wraps `extract_counts_from_image_bytes` in `asyncio.to_thread`, matching the spec requirement to keep the listener responsive.【F:cogs/shards/cog.py†L82-L91】
+- ✅ **Scan button defers ephemerally before heavy work.** The scan callback calls `inter.response.defer(ephemeral=True, thinking=True)` prior to reading from cache/OCR, matching the spec.【F:cogs/shards/cog.py†L168-L205】
+- ✅ **OCR preview is ephemeral with Use/Manual/Retry/Close actions.** The follow-up response posts the preview with an ephemeral view that wires those four buttons, in line with the described UX.【F:cogs/shards/cog.py†L193-L305】
+- ✅ **Retry clears the cache before re-running OCR.** `_retry` pops the cache entry for the `(guild, channel, message)` key then rebuilds it, which satisfies “Retry resets cache.”【F:cogs/shards/cog.py†L185-L278】
+- ✅ **Counts are cached per (guild, channel, message).** The tuple key uses guild/thread/message IDs as specified.【F:cogs/shards/cog.py†L185-L190】
+- ✅ **All-zero OCR results trigger debug ROI uploads.** The background task posts grayscale/binarized ROIs when the sum of counts is zero, matching the requirement.【F:cogs/shards/cog.py†L142-L157】
+- ✅ **Staff diagnostics exist.** `!ocr info` and `!ocr selftest` commands mirror the spec’s tooling.【F:cogs/shards/cog.py†L345-L382】
+- ❌ **Manual entry (Skip OCR) button is missing on the first public panel.** The public prompt only includes “Scan Image” and “Dismiss,” so the manual-first path is absent. *Fix:* add a third button to the initial view that opens the manual modal without touching OCR/cache.【F:cogs/shards/cog.py†L159-L333】
+- ❌ **Manual entry path is unavailable when no image is attached.** The listener exits early if the message lacks an image, so the manual-first requirement “available even without an attachment” is unmet. *Fix:* allow the manual button to be shown (or a manual-only prompt) even when attachments are missing, gated to shard threads to avoid spam.【F:cogs/shards/cog.py†L133-L166】
+
+## OCR Pipeline Parameters
+- ✅ **Crop ratios match 0.38/0.42/0.46.**【F:cogs/shards/ocr.py†L144-L206】
+- ✅ **Binarize threshold 160 with MaxFilter(3).**【F:cogs/shards/ocr.py†L235-L245】
+- ✅ **PSM order (6 then 11) and OEM 3 are respected.**【F:cogs/shards/ocr.py†L361-L378】
+- ✅ **Left-side gate clamps at 60% of ROI width.**【F:cogs/shards/ocr.py†L367-L401】
+- ✅ **Confidence floor at 18 before accepting tokens.**【F:cogs/shards/ocr.py†L391-L405】
+
+## Miscellaneous
+- ✅ **OCR runs in a background thread for self-test and runtime info is logged once on cog init, aligning with expectations for diagnostics visibility.**【F:cogs/shards/cog.py†L34-L61】【F:cogs/shards/ocr.py†L100-L119】

--- a/UI_FLOW_MAP.md
+++ b/UI_FLOW_MAP.md
@@ -1,0 +1,24 @@
+# UI Flow Map — Shard Threads
+
+## Trigger: Message in clan shard thread
+- Preconditions: user message in a configured shard thread with an image attachment (current implementation ignores messages without images).【F:cogs/shards/cog.py†L128-L140】
+- Bot action: posts a **public** prompt message with persistent buttons (timeout 5 minutes).【F:cogs/shards/cog.py†L159-L343】
+  - **Scan Image** (primary) → goes to *OCR Preview* flow (ephemeral).【F:cogs/shards/cog.py†L168-L305】
+  - **Dismiss** (secondary) → deletes the public prompt if pressed by author/staff.【F:cogs/shards/cog.py†L310-L327】
+  - **Manual entry (Skip OCR)** — **required addition** per spec. This button should open the manual modal immediately. *(Gap: not yet implemented.)*【F:cogs/shards/cog.py†L159-L333】
+
+> **Edge-case requirement:** Manual-entry button must be available even when a thread message lacks images. Today, the listener returns early and nothing is posted, so the manual path never appears; planned fix is to surface a manual-only button when no image is present.【F:cogs/shards/cog.py†L133-L166】
+
+## Flow: Scan Image → OCR Preview (ephemeral)
+1. **Deferral:** Interaction defers ephemerally with thinking indicator.【F:cogs/shards/cog.py†L179-L205】
+2. **OCR fetch:** Uses cache `(guild, channel, message)`; runs OCR via `asyncio.to_thread` on cache miss.【F:cogs/shards/cog.py†L82-L91】【F:cogs/shards/cog.py†L185-L206】
+3. **Ephemeral panel:** Bot replies ephemerally with `**OCR Preview**` text and a 4-button view (timeout 3 minutes).【F:cogs/shards/cog.py†L193-L305】
+   - **Use these counts** (success) → opens `SetCountsModal` prefilled with OCR values; on submit, writes snapshot and responds ephemerally “Counts saved…”.【F:cogs/shards/cog.py†L209-L234】
+   - **Manual entry** (primary) → opens empty `SetCountsModal`; same save path as above.【F:cogs/shards/cog.py†L235-L259】
+   - **Retry OCR** (secondary) → defers, clears cache, re-runs OCR, edits the original ephemeral preview.【F:cogs/shards/cog.py†L261-L278】
+   - **Close** (danger) → defers and edits the ephemeral message to “Closed.” without buttons.【F:cogs/shards/cog.py†L280-L291】
+
+## Flow: Manual entry (Skip OCR) — *planned*
+- **Entry point:** New button on the public prompt (and fallback when there is no attachment).
+- **Action:** Immediately open `SetCountsModal` with empty fields; bypass OCR/cache entirely.
+- **Post-submit:** Reuse existing manual save logic (snapshot append + summary refresh + ephemeral confirmation).【F:cogs/shards/cog.py†L235-L259】

--- a/issue-batches/shards-epic-refresh.json
+++ b/issue-batches/shards-epic-refresh.json
@@ -1,0 +1,75 @@
+{
+  "milestone": "Shard Module v0.4 — Manual First",
+  "defaults": {
+    "assignees": []
+  },
+  "issues": [
+    {
+      "title": "Epic: OCR v2 (postponed)",
+      "body": "**Why**: Current OCR splits large numbers and mis-assigns wide screenshots; we are deferring improvements until manual-first UX and emoji compliance land.\n\n**Scope**: Token stitching, per-band PSM7 tuning, smarter ROI scoring, richer debug output.\n\n**Blocked by**: Manual-entry rollout assessment.",
+      "labels": ["bot: achievements", "area: shards", "type: epic", "status: blocked"],
+      "acceptance_criteria": [
+        "Successor issues created for token stitching, per-band OCR tuning, and debug UX.",
+        "Rollout plan approved by staff once manual-first is stable."
+      ],
+      "non_goals": [
+        "Do not change shard thread triggers or manual-entry surfaces.",
+        "Do not ship OCR model swaps (keep Tesseract 5.5)."
+      ],
+      "test_plan": [
+        "Document validation scenarios for each child issue before unblocking."
+      ],
+      "rollout_notes": [
+        "Mark epic as ready only after Manual First milestone completes."
+      ]
+    },
+    {
+      "title": "Feature: Add \"Manual entry (Skip OCR)\" on first panel",
+      "body": "**Why**: Clan staff need a zero-OCR path to enter counts immediately, even when screenshots fail or are absent.\n\n**Scope**: Add manual-entry button to the public shard prompt, reuse existing modal flow, make it accessible without attachments, and ensure audit logging stays the same.",
+      "labels": ["bot: achievements", "area: shards", "type: feature", "status: ready"],
+      "acceptance_criteria": [
+        "First-panel prompt shows Manual entry (Skip OCR) alongside Scan/Dismiss.",
+        "Pressing the new button opens the manual modal without invoking OCR or touching cache.",
+        "Manual-entry path is available when no screenshot is attached (in shard threads only).",
+        "Logging/Sheets rows continue tagging these entries as manual."
+      ],
+      "non_goals": [
+        "Do not change OCR retry behavior or cache policy.",
+        "Do not alter manual modal fields beyond emoji updates handled separately."
+      ],
+      "test_plan": [
+        "Post shard screenshot, press Manual entry, submit counts → verify summary updates.",
+        "Post text-only message in shard thread, use Manual entry → verify modal opens and saves.",
+        "Ensure Scan button stays disabled or errors gracefully when no attachment is present."
+      ],
+      "rollout_notes": [
+        "Announce change in shard threads before enabling to avoid confusion.",
+        "Monitor logs for manual submissions during first 48 hours."
+      ]
+    },
+    {
+      "title": "Feature: Use custom server shard emojis everywhere",
+      "body": "**Why**: Policy requires shard counters and UI to display server-specific emoji, not unicode placeholders.\n\n**Scope**: Introduce a central emoji mapping (JSON + helper), validate Sheets overrides, and replace unicode fallbacks across cog, views, renderer, and help copy.",
+      "labels": ["bot: achievements", "area: shards", "type: feature", "status: ready"],
+      "acceptance_criteria": [
+        "Shared emoji mapping file committed with server IDs.",
+        "OCR preview, manual modal, mercy buttons, and summary embeds render custom emojis.",
+        "Help text/commands reflect the same emoji set.",
+        "Log warning when mapping fallback (unicode) is hit so staff can remediate."
+      ],
+      "non_goals": [
+        "Do not change sheet schema beyond validating emoji columns.",
+        "Do not modify non-shard emoji usage (e.g., claims)."
+      ],
+      "test_plan": [
+        "Trigger OCR preview and confirm emojis render as `<:name:id>` in Discord.",
+        "Open manual modal to verify labels/buttons show custom emojis.",
+        "Run `!shards help` and ensure text matches the mapping."
+      ],
+      "rollout_notes": [
+        "Coordinate with art team to upload emoji assets before deploy.",
+        "Update configuration doc with emoji ID references."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- document spec matches/gaps, UI flow, emoji audit, and readiness gate for the shard module
- capture issue audit results and supply a refreshed issue batch for manual-first and emoji work
- outline manual-first and emoji mapping patch plans and compile the overall shard audit report

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e63c8112e483239adab0510df63a46