### PR TITLE
Simplify bot startup and keepalive settings

### DIFF
--- a/c1c_claims_appreciation.py
+++ b/c1c_claims_appreciation.py
@@ -199,10 +199,6 @@ def _health_payload() -> tuple[dict, int]:
 
 async def _maybe_restart(reason: str) -> None:
     log.error("[WATCHDOG] Restarting: %s", reason)
-    try:
-        await bot.close()
-    except Exception:
-        pass
     raise SystemExit(1)
 
 
@@ -240,7 +236,15 @@ def health():
 
 def keep_alive():
     port = int(os.getenv("PORT", "10000"))
-    threading.Thread(target=lambda: app.run(host="0.0.0.0", port=port), daemon=True).start()
+    threading.Thread(
+        target=lambda: app.run(
+            host="0.0.0.0",
+            port=port,
+            debug=False,
+            use_reloader=False,
+        ),
+        daemon=True,
+    ).start()
     
 # ---------------- discord client ----------------
 intents = discord.Intents.default()
@@ -1781,49 +1785,22 @@ async def on_ready():
 
 
 async def _run_bot(token: str) -> None:
-    base_delay = 5
-    attempt = 0
-
-    while True:
-        try:
-            await bot.login(token)
-            attempt = 0
-            await bot.connect(reconnect=True)
-            log.info("Bot connection closed gracefully; exiting run loop")
-            break
-        except discord.LoginFailure as e:
-            log.error("Login failed: %s", e)
-            raise
-        except ClientConnectorError as e:
-            attempt += 1
-            wait = min(600, base_delay * (2 ** (attempt - 1)))
-            log.warning("[startup] Network connect error: %s — retrying in %ss", e, wait)
-            await asyncio.sleep(wait)
-        except discord.HTTPException as e:
-            attempt += 1
-            wait = min(600, base_delay * (2 ** (attempt - 1)))
-            status = getattr(e, "status", None)
-            message = str(e)
-            if status in {429, 503} or "rate limited" in message.lower() or "banned" in message.lower():
-                log.warning(
-                    "[startup] Discord refused the connection (status=%s). Cooling down for %ss before retry.",
-                    status,
-                    wait,
-                )
-            else:
-                log.exception("[startup] discord.HTTPException (status=%s)", status)
-            await asyncio.sleep(wait)
-        except Exception as e:
-            attempt += 1
-            wait = min(600, base_delay * (2 ** (attempt - 1)))
-            log.exception("[startup] Unexpected exception: %s — retrying in %ss", e, wait)
-            await asyncio.sleep(wait)
-        finally:
-            if not bot.is_closed():
-                try:
-                    await bot.close()
-                except Exception:
-                    pass
+    try:
+        # start() handles login + connect and manages its own HTTP session lifecycle.
+        await bot.start(token, reconnect=True)
+    except discord.LoginFailure as e:
+        log.error("Login failed: %s", e)
+        raise
+    except Exception as e:
+        # If anything fatal happens, exit so Render can restart the service cleanly.
+        log.exception("[startup] Fatal exception; exiting so platform can restart: %s", e)
+        raise
+    finally:
+        if not bot.is_closed():
+            try:
+                await bot.close()
+            except Exception:
+                pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Improve process lifecycle handling so the platform (e.g., Render) can restart the service cleanly when the watchdog triggers by exiting the process. 
- Avoid Flask debug/reloader creating duplicate threads in the keep-alive web server. 
- Rely on the library-managed bot lifecycle instead of a custom login/connect/retry loop for simpler, more robust startup.

### Description
- In `_maybe_restart`, removed the attempt to `await bot.close()` so the watchdog now logs and exits with `SystemExit(1)` immediately. 
- In `keep_alive()`, start the Flask thread with `debug=False` and `use_reloader=False` to prevent the reloader from spawning duplicate worker threads. 
- Replaced the manual login/connect/backoff loop in `_run_bot` with a call to `await bot.start(token, reconnect=True)` and added centralized exception logging and cleanup, keeping a `finally` block that closes the bot if needed. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974993f9c488323ba5539f7d5a0f388)