### PR TITLE
Add passive help metadata decorators and annotate commands

### DIFF
--- a/achievements/__init__.py
+++ b/achievements/__init__.py
@@ -1,0 +1,1 @@
+"""Achievements bot helper package."""

--- a/achievements/help_metadata.py
+++ b/achievements/help_metadata.py
@@ -1,0 +1,99 @@
+"""Passive Woadkeeper-compatible command help metadata helpers.
+
+This metadata is for future shared HelpCommands export and Woadkeeper-owned
+help rendering. It is intentionally passive and does not drive Achievements'
+current local help output yet.
+
+Supported decorator order keeps ``@commands.command(...)`` directly below the
+metadata decorators so Python applies it first::
+
+    @help_metadata(...)
+    @tier("user")
+    @commands.command(...)
+    async def command(...):
+        ...
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, TypeVar
+
+from discord.ext import commands
+
+VALID_TIERS = frozenset({"user", "staff", "admin", "hidden"})
+VALID_ACCESS_TIERS = frozenset({"user", "staff", "admin", "hidden"})
+
+T = TypeVar("T", bound=commands.Command)
+
+
+def _require_command(obj: Any, decorator_name: str) -> commands.Command:
+    if not isinstance(obj, commands.Command):
+        raise TypeError(
+            f"@{decorator_name} must be applied above @commands.command "
+            "so it receives a discord.py Command object."
+        )
+    return obj
+
+
+def _validate(value: str, valid: frozenset[str], label: str) -> str:
+    if value not in valid:
+        allowed = ", ".join(sorted(valid))
+        raise ValueError(f"Invalid {label} {value!r}; expected one of: {allowed}")
+    return value
+
+
+def _normalize_flags(flags: Iterable[str] | None) -> tuple[str, ...]:
+    if flags is None:
+        return ()
+    normalized = tuple(str(flag) for flag in flags)
+    if any(not flag for flag in normalized):
+        raise ValueError("help metadata flags must be non-empty strings")
+    return normalized
+
+
+def tier(value: str):
+    """Mark a discord.py command with an RBAC/help tier."""
+    checked = _validate(value, VALID_TIERS, "tier")
+
+    def decorator(command: T) -> T:
+        checked_command = _require_command(command, "tier")
+        checked_command.extras["tier"] = checked
+        setattr(checked_command, "_tier", checked)
+        return command
+
+    return decorator
+
+
+def help_metadata(
+    *,
+    function_group: str,
+    section: str,
+    access_tier: str,
+    usage: str | None = None,
+    flags: Iterable[str] | None = None,
+):
+    """Attach passive shared-help metadata to a discord.py command."""
+    checked_access = _validate(access_tier, VALID_ACCESS_TIERS, "access_tier")
+    normalized_flags = _normalize_flags(flags)
+
+    def decorator(command: T) -> T:
+        checked_command = _require_command(command, "help_metadata")
+        checked_command.extras["function_group"] = function_group
+        checked_command.extras["help_section"] = section
+        checked_command.extras["access_tier"] = checked_access
+        checked_command.extras["help_usage"] = usage
+        checked_command.extras["help_flags"] = normalized_flags
+        return command
+
+    return decorator
+
+
+def get_help_metadata(command: commands.Command) -> dict[str, Any]:
+    """Return only the helper-owned shared-help metadata fields."""
+    checked_command = _require_command(command, "get_help_metadata")
+    extras = checked_command.extras
+    return {
+        key: extras.get(key)
+        for key in ("function_group", "help_section", "access_tier", "help_usage", "help_flags")
+    }

--- a/c1c_claims_appreciation.py
+++ b/c1c_claims_appreciation.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 import discord
 from discord.ext import commands, tasks
+from achievements.help_metadata import help_metadata, tier
 from flask import Flask, jsonify, request
 from aiohttp import ClientConnectorError, ClientSession, ClientTimeout
 
@@ -1364,6 +1365,8 @@ def _is_staff(member: discord.Member) -> bool:
     return bool(rid and any(r.id == rid for r in member.roles))
 
 # ---------------- help ----------------
+@help_metadata(function_group="claims", section="claims", access_tier="user", usage="!help [topic]", flags=("local_help", "transitional"))
+@tier("user")
 @bot.command(name="help")
 async def help_cmd(ctx: commands.Context, *, topic: str = None):
     topic = (topic or "").strip().lower()
@@ -1397,6 +1400,8 @@ async def help_cmd(ctx: commands.Context, *, topic: str = None):
     await ctx.reply(embed=e, mention_author=False)
 
 # ---------------- admin/test commands ----------------
+@help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!testconfig", flags=("diagnostic",))
+@tier("staff")
 @bot.command(name="testconfig")
 async def testconfig(cmdx: commands.Context):
     if not _is_staff(cmdx.author):
@@ -1425,6 +1430,8 @@ async def testconfig(cmdx: commands.Context):
     )
     await safe_send_embed(cmdx, emb)
 
+@help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!configstatus", flags=("diagnostic",))
+@tier("staff")
 @bot.command(name="configstatus")
 async def configstatus(ctx: commands.Context):
     if not _is_staff(ctx.author):
@@ -1432,6 +1439,8 @@ async def configstatus(ctx: commands.Context):
     loaded_at = CONFIG_META["loaded_at"].strftime("%Y-%m-%d %H:%M:%S UTC") if CONFIG_META["loaded_at"] else "—"
     await ctx.send(f"Source: **{CONFIG_META['source']}** | Loaded: **{loaded_at}** | Ach={len(ACHIEVEMENTS)} Cat={len(CATEGORIES)} Lvls={len(LEVELS)}")
 
+@help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!reloadconfig")
+@tier("staff")
 @bot.command(name="reloadconfig")
 async def reloadconfig(ctx: commands.Context):
     if not _is_staff(ctx.author):
@@ -1443,6 +1452,8 @@ async def reloadconfig(ctx: commands.Context):
     except Exception as e:
         await ctx.send(f"Reload failed: `{e}`")
 
+@help_metadata(function_group="achievements", section="admin_maintenance", access_tier="staff", usage="!listach [filter]")
+@tier("staff")
 @bot.command(name="listach")
 async def listach(ctx: commands.Context, filter_text: str = ""):
     if not _is_staff(ctx.author):
@@ -1456,6 +1467,8 @@ async def listach(ctx: commands.Context, filter_text: str = ""):
     chunk = ", ".join(keys[:60])
     await ctx.send(f"**Loaded achievements ({len(keys)}):** {chunk}{' …' if len(keys) > 60 else ''}")
 
+@help_metadata(function_group="achievements", section="admin_maintenance", access_tier="staff", usage="!findach <text>")
+@tier("staff")
 @bot.command(name="findach")
 async def findach(ctx: commands.Context, *, text: str):
     if not _is_staff(ctx.author):
@@ -1470,6 +1483,8 @@ async def findach(ctx: commands.Context, *, text: str):
         return await ctx.send("No matches.")
     await ctx.send("\n".join(hits[:20]))
 
+@help_metadata(function_group="achievements", section="testing", access_tier="staff", usage="!testach <key> [where]", flags=("test",))
+@tier("staff")
 @bot.command(name="testach")
 async def testach(ctx: commands.Context, key: str, where: Optional[str] = None):
     if not _is_staff(ctx.author):
@@ -1486,6 +1501,8 @@ async def testach(ctx: commands.Context, key: str, where: Optional[str] = None):
     if target.id != ctx.channel.id:
         await ctx.reply(f"Preview sent to {target.mention}", mention_author=False)
 
+@help_metadata(function_group="achievements", section="testing", access_tier="staff", usage="!testlevel [query] [where]", flags=("test",))
+@tier("staff")
 @bot.command(name="testlevel")
 async def testlevel(ctx: commands.Context, *, args: str = ""):
     if not _is_staff(ctx.author):
@@ -1509,6 +1526,8 @@ async def testlevel(ctx: commands.Context, *, args: str = ""):
     if target.id != ctx.channel.id:
         await ctx.reply(f"Preview sent to {target.mention}", mention_author=False)
 
+@help_metadata(function_group="claims", section="admin_maintenance", access_tier="staff", usage="!flushpraise")
+@tier("staff")
 @bot.command(name="flushpraise")
 async def flushpraise(ctx: commands.Context):
     if not _is_staff(ctx.author):
@@ -1520,6 +1539,8 @@ async def flushpraise(ctx: commands.Context):
         await _flush_group(ctx.guild, uid)
     await ctx.send("Flushed pending praise for this server.")
 
+@help_metadata(function_group="operational", section="members", access_tier="user", usage="!ping")
+@tier("user")
 @bot.command(name="ping")
 async def ping(ctx: commands.Context):
     # react-only liveness check

--- a/claims/help.py
+++ b/claims/help.py
@@ -2,6 +2,7 @@
 
 import os
 import discord
+from achievements.help_metadata import help_metadata, tier
 from datetime import datetime
 
 try:
@@ -132,6 +133,8 @@ async def setup(bot):
 
     import os
 
+    @help_metadata(function_group="claims", section="claims", access_tier="user", usage="!help [topic]", flags=("local_help", "transitional"))
+    @tier("user")
     @bot.command(name="help")
     async def help_cmd(ctx, *, topic: str | None = None):
         ver = os.getenv("BOT_VERSION", "dev")

--- a/cogs/ops.py
+++ b/cogs/ops.py
@@ -5,6 +5,7 @@ import os, json, pathlib, hashlib, time, platform
 import importlib, inspect
 import discord
 from discord.ext import commands
+from achievements.help_metadata import help_metadata, tier
 import logging
 
 from core.prefix import SCOPED_PREFIXES, get_prefix
@@ -56,6 +57,8 @@ class OpsCog(commands.Cog):
             pass
 
     # ---------------- core ops commands (staff-only; non-staff get prefix picker) ----------------
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!health", flags=('diagnostic',))
+    @tier("staff")
     @commands.command(name="health")
     async def health_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -107,6 +110,8 @@ class OpsCog(commands.Cog):
         emb = build_health_embed(app.BOT_VERSION, summary)
         await app.safe_send_embed(ctx, emb)
 
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!digest", flags=('diagnostic',))
+    @tier("staff")
     @commands.command(name="digest")
     async def digest_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -162,6 +167,8 @@ class OpsCog(commands.Cog):
         line = build_digest_line(summary)
         await ctx.send(line)
 
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!reload")
+    @tier("staff")
     @commands.command(name="reload")
     async def reload_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -186,6 +193,8 @@ class OpsCog(commands.Cog):
         except Exception as e:
             await ctx.send(f"Reload failed: `{e}`")
 
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!checksheet", flags=('diagnostic',))
+    @tier("staff")
     @commands.command(name="checksheet")
     async def checksheet_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -236,6 +245,8 @@ class OpsCog(commands.Cog):
         emb = build_checksheet_embed(app.BOT_VERSION, backend, items)
         await app.safe_send_embed(ctx, emb)
 
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!env", flags=('diagnostic',))
+    @tier("staff")
     @commands.command(name="env")
     async def env_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -255,6 +266,8 @@ class OpsCog(commands.Cog):
         emb = build_env_embed(app.BOT_VERSION, env_info)
         await app.safe_send_embed(ctx, emb)
 
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!build", flags=('diagnostic', 'hidden'))
+    @tier("staff")
     @commands.command(name="build")
     async def build_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -309,6 +322,8 @@ class OpsCog(commands.Cog):
 
         await ctx.reply("\n".join(lines), mention_author=False)
 
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!reboot")
+    @tier("staff")
     @commands.command(name="reboot", aliases=["restart", "rb"])
     async def reboot_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)

--- a/cogs/shards/cog.py
+++ b/cogs/shards/cog.py
@@ -14,6 +14,7 @@ import cv2
 import discord
 import numpy as np
 from discord.ext import commands
+from achievements.help_metadata import help_metadata, tier
 
 from .constants import ShardType, Rarity, DISPLAY_ORDER
 from . import sheets_adapter as SA
@@ -436,6 +437,8 @@ class ShardsCog(commands.Cog):
         asyncio.create_task(_drop())
 
     # ---------- OCR DIAGNOSTICS ----------
+    @help_metadata(function_group="diagnostics", section="diagnostics", access_tier="hidden", usage="!ocrdebug", flags=("diagnostic", "hidden"))
+    @tier("hidden")
     @commands.command(name="ocrdebug")
     @commands.guild_only()
     async def ocr_debug_cmd(self, ctx: commands.Context):
@@ -555,6 +558,8 @@ class ShardsCog(commands.Cog):
 
         await ctx.reply(embed=embed, files=_with_overlay(), mention_author=False)
 
+    @help_metadata(function_group="diagnostics", section="diagnostics", access_tier="hidden", usage="!ocrdiag", flags=("diagnostic", "hidden"))
+    @tier("hidden")
     @commands.command(name="ocrdiag")
     @commands.guild_only()
     async def ocr_diag_cmd(self, ctx: commands.Context):
@@ -621,6 +626,8 @@ class ShardsCog(commands.Cog):
 
         await ctx.reply("\n".join(lines), mention_author=False)
 
+    @help_metadata(function_group="diagnostics", section="diagnostics", access_tier="staff", usage="!ocr <info|selftest>", flags=("diagnostic",))
+    @tier("staff")
     @commands.command(name="ocr")
     async def ocr_cmd(self, ctx: commands.Context, sub: Optional[str] = None):
         """
@@ -661,6 +668,8 @@ class ShardsCog(commands.Cog):
         await ctx.reply("Usage: `!ocr info` or `!ocr selftest`.", mention_author=False)
 
     # ---------- COMMANDS ----------
+    @help_metadata(function_group="leaderboard", section="progress", access_tier="user", usage="!shards [help|set]")
+    @tier("user")
     @commands.command(name="shards")
     async def shards_cmd(self, ctx: commands.Context, sub: Optional[str] = None, *, tail: Optional[str] = None):
         if not isinstance(ctx.channel, discord.Thread) or not self._is_shard_thread(ctx.channel):
@@ -729,6 +738,8 @@ class ShardsCog(commands.Cog):
         view.add_item(btn)
         await ctx.reply("Click to open the form:", view=view)
 
+    @help_metadata(function_group="leaderboard", section="progress", access_tier="user", usage="!mercy addpulls")
+    @tier("user")
     @commands.command(name="mercy")
     async def mercy_cmd(self, ctx: commands.Context, sub: Optional[str] = None, *, tail: Optional[str] = None):
         if not isinstance(ctx.channel, discord.Thread) or not self._is_shard_thread(ctx.channel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_command_metadata_annotations.py
+++ b/tests/test_command_metadata_annotations.py
@@ -1,0 +1,83 @@
+import pytest
+pytest.importorskip("discord")
+import importlib
+
+from achievements.help_metadata import VALID_ACCESS_TIERS
+
+METADATA_KEYS = {"function_group", "help_section", "access_tier", "help_usage", "help_flags", "tier"}
+
+
+def assert_metadata(command, access_tier=None):
+    missing = [key for key in METADATA_KEYS if key not in command.extras]
+    assert not missing, f"{command.qualified_name} missing metadata keys: {missing}"
+    assert command.extras["access_tier"] in VALID_ACCESS_TIERS
+    assert command.extras["tier"] in VALID_ACCESS_TIERS
+    if access_tier:
+        assert command.extras["access_tier"] == access_tier
+        assert command.extras["tier"] == access_tier
+
+
+def test_monolith_registered_commands_have_metadata_and_help_remains():
+    app = importlib.import_module("c1c_claims_appreciation")
+    names = {command.name for command in app.bot.commands}
+
+    expected = {
+        "help", "testconfig", "configstatus", "reloadconfig", "listach",
+        "findach", "testach", "testlevel", "flushpraise", "ping",
+    }
+    assert expected.issubset(names)
+    assert "helpseed" not in names
+
+    for command in app.bot.commands:
+        if command.name in expected:
+            assert_metadata(command)
+
+    assert_metadata(app.bot.get_command("help"), "user")
+    assert_metadata(app.bot.get_command("ping"), "user")
+    assert app.bot.get_command("ping").extras["function_group"] == "operational"
+    assert app.bot.get_command("ping").extras["help_section"] == "members"
+    assert app.bot.get_command("help").extras["help_flags"] == ("local_help", "transitional")
+
+
+def test_admin_staff_monolith_commands_keep_runtime_staff_checks():
+    app = importlib.import_module("c1c_claims_appreciation")
+    staff_commands = ["testconfig", "configstatus", "reloadconfig", "listach", "findach", "testach", "testlevel", "flushpraise"]
+    for name in staff_commands:
+        cmd = app.bot.get_command(name)
+        assert_metadata(cmd, "staff")
+        names = set(cmd.callback.__code__.co_names)
+        assert "_is_staff" in names
+
+
+def test_cog_command_objects_have_metadata_aliases_and_hidden_diagnostics():
+    ops = importlib.import_module("cogs.ops")
+    shards = importlib.import_module("cogs.shards.cog")
+
+    ops_commands = {
+        "health": ops.OpsCog.health_cmd,
+        "digest": ops.OpsCog.digest_cmd,
+        "reload": ops.OpsCog.reload_cmd,
+        "checksheet": ops.OpsCog.checksheet_cmd,
+        "env": ops.OpsCog.env_cmd,
+        "build": ops.OpsCog.build_cmd,
+        "reboot": ops.OpsCog.reboot_cmd,
+    }
+    for command in ops_commands.values():
+        assert_metadata(command, "staff")
+    assert ops.OpsCog.reboot_cmd.aliases == ["restart", "rb"]
+
+    assert_metadata(shards.ShardsCog.ocr_debug_cmd, "hidden")
+    assert_metadata(shards.ShardsCog.ocr_diag_cmd, "hidden")
+    assert_metadata(shards.ShardsCog.ocr_cmd, "staff")
+    assert_metadata(shards.ShardsCog.shards_cmd, "user")
+    assert_metadata(shards.ShardsCog.mercy_cmd, "user")
+
+
+def test_help_only_topics_do_not_create_fake_commands():
+    app = importlib.import_module("c1c_claims_appreciation")
+    runnable = {command.name for command in app.bot.commands}
+
+    assert "claim" not in runnable
+    assert "claims" not in runnable
+    assert "gk" not in runnable
+    assert "helpseed" not in runnable

--- a/tests/test_help_metadata.py
+++ b/tests/test_help_metadata.py
@@ -1,0 +1,92 @@
+import pytest
+pytest.importorskip("discord")
+from discord.ext import commands
+
+from achievements.help_metadata import (
+    VALID_ACCESS_TIERS,
+    VALID_TIERS,
+    get_help_metadata,
+    help_metadata,
+    tier,
+)
+
+
+def make_command():
+    async def callback(ctx):
+        return None
+
+    return commands.Command(callback, name="sample", extras={"kept": "value"})
+
+
+@pytest.mark.parametrize("tier_name", sorted(VALID_TIERS))
+def test_tier_stores_extras_and_private_tier(tier_name):
+    cmd = tier(tier_name)(make_command())
+
+    assert cmd.extras["tier"] == tier_name
+    assert cmd._tier == tier_name
+    assert cmd.extras["kept"] == "value"
+
+
+def test_invalid_tier_raises_clearly():
+    with pytest.raises(ValueError, match="Invalid tier"):
+        tier("moderator")
+
+
+def test_help_metadata_stores_expected_fields_and_preserves_extras():
+    cmd = help_metadata(
+        function_group="achievements",
+        section="progress",
+        access_tier="user",
+        usage="!sample [arg]",
+        flags=["diagnostic", "hidden"],
+    )(make_command())
+
+    assert cmd.extras["kept"] == "value"
+    assert get_help_metadata(cmd) == {
+        "function_group": "achievements",
+        "help_section": "progress",
+        "access_tier": "user",
+        "help_usage": "!sample [arg]",
+        "help_flags": ("diagnostic", "hidden"),
+    }
+
+
+def test_invalid_access_tier_raises_clearly():
+    with pytest.raises(ValueError, match="Invalid access_tier"):
+        help_metadata(function_group="x", section="y", access_tier="moderator")
+
+
+def test_flags_normalize_to_stable_tuple_of_strings():
+    cmd = help_metadata(function_group="x", section="y", access_tier="hidden", flags=["b", 7])(make_command())
+    assert cmd.extras["help_flags"] == ("b", "7")
+
+
+def test_tier_rejects_raw_function_with_clear_message():
+    async def raw(ctx):
+        return None
+
+    with pytest.raises(TypeError, match="@tier must be applied above @commands.command"):
+        tier("user")(raw)
+
+
+def test_help_metadata_rejects_raw_function_with_clear_message():
+    async def raw(ctx):
+        return None
+
+    decorator = help_metadata(function_group="x", section="y", access_tier="user")
+    with pytest.raises(TypeError, match="@help_metadata must be applied above @commands.command"):
+        decorator(raw)
+
+
+def test_decorator_order_used_in_repo_with_command_then_permission_decorator():
+    @help_metadata(function_group="diagnostics", section="diagnostics", access_tier="hidden", usage="!ordered")
+    @tier("hidden")
+    @commands.guild_only()
+    @commands.command(name="ordered")
+    async def ordered(ctx):
+        return None
+
+    assert ordered.extras["tier"] == "hidden"
+    assert ordered.extras["access_tier"] == "hidden"
+    assert ordered.extras["help_usage"] == "!ordered"
+    assert ordered.checks  # guild_only check is preserved


### PR DESCRIPTION
### Motivation
- Introduce passive, Woadkeeper-compatible help metadata so commands can be annotated with RBAC tiers and shared-help fields without changing local help rendering.
- Provide stable, testable decorators to mark commands as `user`/`staff`/`admin`/`hidden` and attach function group, section, usage and flags for future help exports.
- Ensure existing runtime permission checks and command behavior remain unchanged while enabling downstream help tooling and documentation.

### Description
- Add new helper package `achievements.help_metadata` implementing `help_metadata`, `tier`, `get_help_metadata`, validation helpers, and stable flag normalization.
- Annotate a number of commands across the monolith and cogs with `@help_metadata(...)` and `@tier(...)`, including updates to `c1c_claims_appreciation.py`, `claims/help.py`, `cogs/ops.py`, and `cogs/shards/cog.py` to attach metadata without altering runtime checks.
- Add lightweight test support `tests/conftest.py` and unit tests `tests/test_help_metadata.py` and `tests/test_command_metadata_annotations.py` that verify decorator behavior, metadata presence, decorator ordering, and that staff checks remain present.
- Minor import additions where decorators are applied and a module docstring `achievements/__init__.py`.

### Testing
- Executed the new unit test suite with `pytest`, which includes `tests/test_help_metadata.py` and `tests/test_command_metadata_annotations.py`, and the run completed successfully.
- Tests validate that commands expose the expected extras keys via `Command.extras`, decorator order is enforced, flags normalize to tuples, and existing runtime staff checks remain in command callbacks.
- Tests are guarded with `pytest.importorskip("discord")` so they run when Discord dependencies are present and were included in the CI test run that passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b7796c1f08323bdfbb9661f3d54b6)