### PR TITLE
Refactor admin/staff permission checks, remove local help, and improve help-seed/export documentation

### DIFF
--- a/achievements/help_seed.py
+++ b/achievements/help_seed.py
@@ -254,7 +254,7 @@ def seed_help_commands(bot: commands.Bot, worksheet) -> SeedResult:
             if row_map["access_level"]:
                 new[col["access_level"]] = row_map["access_level"]
             for h in ("category", "summary", "details"):
-                if not new[col[h]]:
+                if not str(new[col[h]] or "").strip():
                     new[col[h]] = row_map[h]
             updates.append({"range": f"A{rownum}:{_a1(rownum, len(headers))}", "values": [new]})
             result.updated += 1

--- a/c1c_claims_appreciation.py
+++ b/c1c_claims_appreciation.py
@@ -508,16 +508,14 @@ async def setup_hook():
             log.warning(f"[cogs] failed {name}: {e}")
             return False
 
-    # Load the NEW help (not the old middleware one)
-    await _load("claims.help")
+    # Achievements no longer registers a local !help command; Woadkeeper will own shared help.
 
     # CoreOps: prefer cogs/ops.py, fallback to claims/middleware/ops.py
     loaded_ops = await _load("cogs.ops")
     if not loaded_ops:
         await _load("claims.middleware.ops")
 
-    # 🔹 Add the Shards & Mercy module
-    await _load("cogs.shards")
+    # Shards/Mercy and OCR commands are no longer part of Achievements command surface.
 
 # ---------------- helpers ----------------
 def _is_image(att: discord.Attachment) -> bool:
@@ -1359,46 +1357,25 @@ async def process_claim(itx: discord.Interaction, ach_key: str,
         await _one(att)
 
 # ---------------- staff guard ----------------
+def _is_admin(member: discord.Member) -> bool:
+    """Return True for members with server-level admin privileges.
+
+    Achievements admin-only commands use Discord guild permissions and fail
+    closed when permission data is unavailable. Guardian Knight/staff roles do
+    not satisfy this check on their own.
+    """
+    perms = getattr(member, "guild_permissions", None)
+    return bool(perms and (getattr(perms, "administrator", False) or getattr(perms, "manage_guild", False)))
+
+
 def _is_staff(member: discord.Member) -> bool:
-    if member.guild_permissions.manage_guild:
+    if _is_admin(member):
         return True
     rid = CFG.get("guardian_knights_role_id")
     return bool(rid and any(r.id == rid for r in member.roles))
 
-# ---------------- help ----------------
-@help_metadata(function_group="claims", section="claims", access_tier="user", usage="!help [topic]", flags=("local_help", "transitional"))
-@tier("user")
-@bot.command(name="help")
-async def help_cmd(ctx: commands.Context, *, topic: str = None):
-    topic = (topic or "").strip().lower()
-
-    # show overview if no topic given
-    if not topic:
-        return await ctx.reply(embed=_mk_help_embed_claims(ctx.guild), mention_author=False)
-
-    pages = {
-        "testconfig":     "`!testconfig`\nShow current configuration: targets, role ids, source & row counts.",
-        "configstatus":   "`!configstatus`\nShort one-line status: source, loaded time, counts.",
-        "reloadconfig":   "`!reloadconfig`\nReload configuration from Google Sheets or Excel.",
-        "listach":        "`!listach [filter]`\nList loaded achievement keys (optionally filtered).",
-        "findach":        "`!findach <text>`\nSearch achievements by key/name/category/text.",
-        "testach":        "`!testach <key> [where]`\nPreview a single achievement embed (optionally to another channel).",
-        "testlevel":      "`!testlevel [query] [where]`\nPreview a level-up embed (optionally to another channel).",
-        "flushpraise":    "`!flushpraise`\nForce-post any buffered praise in this server.",
-        "ping":           "`!ping`\nSimple liveness check.",
-        "claim":          "Post your screenshot **in the configured claims thread**. I’ll guide you via buttons.",
-        "claims":         "Same as `!help claim`.",
-        "gk":             "Guardian Knights review claims that need verification. They can approve/deny or grant a different role.",
-    }
-
-    txt = pages.get(topic)
-    if not txt:
-        logging.getLogger("c1c-claims").warning("Unknown help topic requested: %s", topic)
-        return
-
-    e = discord.Embed(title=f"!help {topic}", description=txt, color=HELP_COLOR)
-    e.set_footer(text=CFG.get("embed_footer_text", "C1C Achievements") or "C1C Achievements")
-    await ctx.reply(embed=e, mention_author=False)
+# ---------------- local help removed ----------------
+# Achievements intentionally does not register !help in this phase.
 
 # ---------------- admin/test commands ----------------
 
@@ -1422,12 +1399,12 @@ async def helpseed(ctx: commands.Context):
         return await ctx.send("Help registry seed failed. Check logs for details.")
     await ctx.send(format_seed_reply(result))
 
-@help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!testconfig", flags=("diagnostic",))
-@tier("staff")
+@help_metadata(function_group="operational", section="admin_maintenance", access_tier="admin", usage="!testconfig", flags=("diagnostic",))
+@tier("admin")
 @bot.command(name="testconfig")
 async def testconfig(cmdx: commands.Context):
-    if not _is_staff(cmdx.author):
-        return await cmdx.send("Staff only.")
+    if not _is_admin(cmdx.author):
+        return await cmdx.send("Admin only.")
 
     thread_txt = await _fmt_chan_or_thread(cmdx.guild, CFG.get("public_claim_thread_id"))
     levels_txt = await _fmt_chan_or_thread(cmdx.guild, CFG.get("levels_channel_id"))
@@ -1452,21 +1429,21 @@ async def testconfig(cmdx: commands.Context):
     )
     await safe_send_embed(cmdx, emb)
 
-@help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!configstatus", flags=("diagnostic",))
-@tier("staff")
+@help_metadata(function_group="operational", section="admin_maintenance", access_tier="admin", usage="!configstatus", flags=("diagnostic",))
+@tier("admin")
 @bot.command(name="configstatus")
 async def configstatus(ctx: commands.Context):
-    if not _is_staff(ctx.author):
-        return await ctx.send("Staff only.")
+    if not _is_admin(ctx.author):
+        return await ctx.send("Admin only.")
     loaded_at = CONFIG_META["loaded_at"].strftime("%Y-%m-%d %H:%M:%S UTC") if CONFIG_META["loaded_at"] else "—"
     await ctx.send(f"Source: **{CONFIG_META['source']}** | Loaded: **{loaded_at}** | Ach={len(ACHIEVEMENTS)} Cat={len(CATEGORIES)} Lvls={len(LEVELS)}")
 
-@help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!reloadconfig")
-@tier("staff")
+@help_metadata(function_group="operational", section="admin_maintenance", access_tier="admin", usage="!reloadconfig")
+@tier("admin")
 @bot.command(name="reloadconfig")
 async def reloadconfig(ctx: commands.Context):
-    if not _is_staff(ctx.author):
-        return await ctx.send("Staff only.")
+    if not _is_admin(ctx.author):
+        return await ctx.send("Admin only.")
     try:
         load_config()
         loaded_at = CONFIG_META["loaded_at"].strftime("%Y-%m-%d %H:%M:%S UTC")
@@ -1474,12 +1451,12 @@ async def reloadconfig(ctx: commands.Context):
     except Exception as e:
         await ctx.send(f"Reload failed: `{e}`")
 
-@help_metadata(function_group="achievements", section="admin_maintenance", access_tier="staff", usage="!listach [filter]")
-@tier("staff")
+@help_metadata(function_group="achievements", section="admin_maintenance", access_tier="admin", usage="!listach [filter]")
+@tier("admin")
 @bot.command(name="listach")
 async def listach(ctx: commands.Context, filter_text: str = ""):
-    if not _is_staff(ctx.author):
-        return await ctx.send("Staff only.")
+    if not _is_admin(ctx.author):
+        return await ctx.send("Admin only.")
     keys = sorted(ACHIEVEMENTS.keys())
     if filter_text:
         f = filter_text.lower()
@@ -1489,12 +1466,12 @@ async def listach(ctx: commands.Context, filter_text: str = ""):
     chunk = ", ".join(keys[:60])
     await ctx.send(f"**Loaded achievements ({len(keys)}):** {chunk}{' …' if len(keys) > 60 else ''}")
 
-@help_metadata(function_group="achievements", section="admin_maintenance", access_tier="staff", usage="!findach <text>")
-@tier("staff")
+@help_metadata(function_group="achievements", section="admin_maintenance", access_tier="admin", usage="!findach <text>")
+@tier("admin")
 @bot.command(name="findach")
 async def findach(ctx: commands.Context, *, text: str):
-    if not _is_staff(ctx.author):
-        return await ctx.send("Staff only.")
+    if not _is_admin(ctx.author):
+        return await ctx.send("Admin only.")
     t = text.lower()
     hits = []
     for k, r in ACHIEVEMENTS.items():
@@ -1505,12 +1482,12 @@ async def findach(ctx: commands.Context, *, text: str):
         return await ctx.send("No matches.")
     await ctx.send("\n".join(hits[:20]))
 
-@help_metadata(function_group="achievements", section="testing", access_tier="staff", usage="!testach <key> [where]", flags=("test",))
-@tier("staff")
+@help_metadata(function_group="achievements", section="testing", access_tier="admin", usage="!testach <key> [where]", flags=("test",))
+@tier("admin")
 @bot.command(name="testach")
 async def testach(ctx: commands.Context, key: str, where: Optional[str] = None):
-    if not _is_staff(ctx.author):
-        return await ctx.send("Staff only.")
+    if not _is_admin(ctx.author):
+        return await ctx.send("Admin only.")
     ach = ACHIEVEMENTS.get(key)
     if not ach:
         close = [k for k in ACHIEVEMENTS.keys() if key.lower() in k.lower()]
@@ -1523,12 +1500,12 @@ async def testach(ctx: commands.Context, key: str, where: Optional[str] = None):
     if target.id != ctx.channel.id:
         await ctx.reply(f"Preview sent to {target.mention}", mention_author=False)
 
-@help_metadata(function_group="achievements", section="testing", access_tier="staff", usage="!testlevel [query] [where]", flags=("test",))
-@tier("staff")
+@help_metadata(function_group="achievements", section="testing", access_tier="admin", usage="!testlevel [query] [where]", flags=("test",))
+@tier("admin")
 @bot.command(name="testlevel")
 async def testlevel(ctx: commands.Context, *, args: str = ""):
-    if not _is_staff(ctx.author):
-        return await ctx.send("Staff only.")
+    if not _is_admin(ctx.author):
+        return await ctx.send("Admin only.")
     parts = args.rsplit(" ", 1) if args else []
     query = parts[0] if parts else ""
     where = parts[1] if len(parts) == 2 else None
@@ -1548,12 +1525,12 @@ async def testlevel(ctx: commands.Context, *, args: str = ""):
     if target.id != ctx.channel.id:
         await ctx.reply(f"Preview sent to {target.mention}", mention_author=False)
 
-@help_metadata(function_group="claims", section="admin_maintenance", access_tier="staff", usage="!flushpraise")
-@tier("staff")
+@help_metadata(function_group="claims", section="admin_maintenance", access_tier="admin", usage="!flushpraise")
+@tier("admin")
 @bot.command(name="flushpraise")
 async def flushpraise(ctx: commands.Context):
-    if not _is_staff(ctx.author):
-        return await ctx.send("Staff only.")
+    if not _is_admin(ctx.author):
+        return await ctx.send("Admin only.")
     g = GROUP.get(ctx.guild.id, {})
     if not g:
         return await ctx.send("Nothing to flush.")
@@ -1561,10 +1538,30 @@ async def flushpraise(ctx: commands.Context):
         await _flush_group(ctx.guild, uid)
     await ctx.send("Flushed pending praise for this server.")
 
-@help_metadata(function_group="operational", section="members", access_tier="user", usage="!ping")
-@tier("user")
-@bot.command(name="ping")
+
+def _document_command(name: str, brief: str, help_text: str) -> None:
+    command = bot.get_command(name)
+    if command is not None:
+        command.brief = brief
+        command.help = help_text
+
+
+_document_command("helpseed", "Seeds Achievements command metadata into HelpCommands.", "Hidden staff maintenance command that reads the Achievements Config tab to locate the shared HelpCommands workbook and upserts exported Achievements commands. It reports created, updated, skipped, and manual-review counts in the channel and does not export itself.")
+_document_command("testconfig", "Shows full Achievements config details.", "Admin check that replies with an embed showing configured claims, levels, audit, and Guardian Knights targets plus the current config source, load time, and loaded row counts. Use it after config changes to verify the bot is pointing at the expected Discord objects and data source.")
+_document_command("configstatus", "Shows a short Achievements config load status.", "Admin check that posts a compact in-channel status line with the current config source, last load time, and loaded achievement, category, and level counts. Use it for a quick confirmation that Achievements has loaded the expected data.")
+_document_command("reloadconfig", "Reloads Achievements config from the configured source.", "Admin operation that reloads Achievements configuration and achievement rows from the configured Google Sheet or local Excel source, then posts the source, reload time, and row counts. Use it after updating config or achievement definitions.")
+_document_command("listach", "Lists loaded achievement keys.", "Admin lookup command that lists the currently loaded achievement keys, optionally filtered by key or display name. It replies in-channel with up to the first 60 matches so admins can confirm available keys before testing or troubleshooting.")
+_document_command("findach", "Searches loaded achievements.", "Admin lookup command that searches loaded achievement keys, display names, categories, titles, and body text for the provided search term. It replies in-channel with matching keys and names to help find the exact key for previewing or troubleshooting.")
+_document_command("testach", "Previews an achievement embed.", "Admin testing command that builds the achievement unlock embed for a specific achievement key. Optionally accepts a target location argument supported by the channel resolver; it posts the preview there and confirms when sent outside the invoking channel.")
+_document_command("testlevel", "Previews a level-up embed.", "Admin testing command that builds a level-up preview embed using an optional search query and optional target location. It uses the first matching loaded level row, or the first level row when no query is supplied, and posts a preview for embed verification.")
+_document_command("flushpraise", "Posts queued praise messages.", "Admin operation that forces any buffered praise messages for the current server to post immediately instead of waiting for normal batching. It replies in-channel when there is nothing queued or after the pending praise has been flushed.")
+
+@help_metadata(function_group="operational", section="members", access_tier="staff", usage="!ping")
+@tier("staff")
+@bot.command(name="ping", brief="Checks whether Achievements is responsive.", help="Staff liveness check that reacts to the invoking message with 🏓 when the bot can process commands. Use it to confirm the Achievements bot is online without changing configuration or posting an embed.")
 async def ping(ctx: commands.Context):
+    if not _is_staff(ctx.author):
+        return await ctx.send("Staff only.")
     # react-only liveness check
     try:
         await ctx.message.add_reaction("🏓")

--- a/cogs/ops.py
+++ b/cogs/ops.py
@@ -31,21 +31,10 @@ SCOPED_PREFIX_SET = {p.lower() for p in SCOPED_PREFIXES}
 
 
 def _coreops_guard(ctx: commands.Context) -> tuple[bool, str]:
-    """
-    Returns (allowed, msg).
-      - If staff: (True, "")
-      - If non-staff using a scoped prefix (e.g. !sc): (False, "Staff only.")
-      - If non-staff without a scoped prefix: (False, picker_text)
-    """
-    if app._is_staff(ctx.author):
+    """Return (allowed, msg) for admin-only CoreOps commands."""
+    if app._is_admin(ctx.author):
         return True, ""
-
-    prefix = (ctx.prefix or "").strip().lower()
-    if prefix in SCOPED_PREFIX_SET:
-        return False, "Staff only."
-
-    cmd_name = ctx.command.name if ctx.command else "this command"
-    return False, format_prefix_picker(cmd_name)
+    return False, "Admin only."
 
 
 class OpsCog(commands.Cog):
@@ -56,9 +45,9 @@ class OpsCog(commands.Cog):
         except Exception:
             pass
 
-    # ---------------- core ops commands (staff-only; non-staff get prefix picker) ----------------
-    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!health", flags=('diagnostic',))
-    @tier("staff")
+    # ---------------- core ops commands (admin-only) ----------------
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="admin", usage="!health", flags=('diagnostic',))
+    @tier("admin")
     @commands.command(name="health")
     async def health_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -110,8 +99,8 @@ class OpsCog(commands.Cog):
         emb = build_health_embed(app.BOT_VERSION, summary)
         await app.safe_send_embed(ctx, emb)
 
-    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!digest", flags=('diagnostic',))
-    @tier("staff")
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="admin", usage="!digest", flags=('diagnostic',))
+    @tier("admin")
     @commands.command(name="digest")
     async def digest_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -167,8 +156,8 @@ class OpsCog(commands.Cog):
         line = build_digest_line(summary)
         await ctx.send(line)
 
-    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!reload")
-    @tier("staff")
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="admin", usage="!reload")
+    @tier("admin")
     @commands.command(name="reload")
     async def reload_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -193,8 +182,8 @@ class OpsCog(commands.Cog):
         except Exception as e:
             await ctx.send(f"Reload failed: `{e}`")
 
-    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!checksheet", flags=('diagnostic',))
-    @tier("staff")
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="admin", usage="!checksheet", flags=('diagnostic',))
+    @tier("admin")
     @commands.command(name="checksheet")
     async def checksheet_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -245,8 +234,8 @@ class OpsCog(commands.Cog):
         emb = build_checksheet_embed(app.BOT_VERSION, backend, items)
         await app.safe_send_embed(ctx, emb)
 
-    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!env", flags=('diagnostic',))
-    @tier("staff")
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="admin", usage="!env", flags=('diagnostic',))
+    @tier("admin")
     @commands.command(name="env")
     async def env_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -266,8 +255,8 @@ class OpsCog(commands.Cog):
         emb = build_env_embed(app.BOT_VERSION, env_info)
         await app.safe_send_embed(ctx, emb)
 
-    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!build", flags=('diagnostic', 'hidden'))
-    @tier("staff")
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="admin", usage="!build", flags=('diagnostic', 'hidden'))
+    @tier("admin")
     @commands.command(name="build")
     async def build_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -322,8 +311,8 @@ class OpsCog(commands.Cog):
 
         await ctx.reply("\n".join(lines), mention_author=False)
 
-    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="staff", usage="!reboot")
-    @tier("staff")
+    @help_metadata(function_group="operational", section="admin_maintenance", access_tier="admin", usage="!reboot")
+    @tier("admin")
     @commands.command(name="reboot", aliases=["restart", "rb"])
     async def reboot_cmd(self, ctx: commands.Context):
         ok, msg = _coreops_guard(ctx)
@@ -368,6 +357,20 @@ class OpsCog(commands.Cog):
                 await app.safe_send_embed(ctx, done)
         except Exception as e:
             await ctx.send(f"Reboot failed: `{e}`")
+
+
+def _document_ops_command(command: commands.Command, brief: str, help_text: str) -> None:
+    command.brief = brief
+    command.help = help_text
+
+
+_document_ops_command(OpsCog.health_cmd, "Shows Achievements runtime health.", "Admin diagnostic that replies with an embed summarizing bot uptime, gateway readiness, latency, last event age, config status, loaded row counts, and configured Discord targets. Use it to troubleshoot whether Achievements is connected and reading expected data.")
+_document_ops_command(OpsCog.digest_cmd, "Posts a compact Achievements health digest.", "Admin diagnostic that replies with a one-line status digest covering runtime, gateway, config, row counts, and target availability. Use it when you need a concise operational snapshot without the full health embed.")
+_document_ops_command(OpsCog.reload_cmd, "Reloads Achievements config and reports counts.", "Admin operation that reacts to the invoking message, reloads Achievements configuration from the configured source, and replies with an embed showing source, reload time, and loaded row counts. Use it after changing Achievements data or config.")
+_document_ops_command(OpsCog.checksheet_cmd, "Checks loaded Achievements sheet sections.", "Admin diagnostic that replies with an embed showing the configured backend and row/header status for General, Achievements, Categories, Levels, and Reasons data. Use it to confirm required sheet sections are populated and readable.")
+_document_ops_command(OpsCog.env_cmd, "Shows safe Achievements environment status.", "Admin diagnostic that replies with an embed showing whether key runtime environment variables are set, along with auto-refresh and watchdog settings. It avoids printing secret values and is useful for deployment troubleshooting.")
+_document_ops_command(OpsCog.build_cmd, "Shows Achievements build/runtime fingerprint.", "Admin diagnostic that replies with Python version, configured git SHA, and selected local file fingerprints used for runtime troubleshooting. Use it to confirm which code build is running in the deployed Achievements process.")
+_document_ops_command(OpsCog.reboot_cmd, "Performs a soft Achievements reboot.", "Admin operation that acknowledges with a rebooting message, reloads Achievements config, and edits or posts a ready embed with current source and row counts. Aliases !restart and !rb invoke the same soft reload behavior.")
 
 
 async def setup(bot: commands.Bot):

--- a/tests/test_command_metadata_annotations.py
+++ b/tests/test_command_metadata_annotations.py
@@ -3,8 +3,28 @@ pytest.importorskip("discord")
 import importlib
 
 from achievements.help_metadata import VALID_ACCESS_TIERS
+from achievements.help_seed import collect_help_rows
 
 METADATA_KEYS = {"function_group", "help_section", "access_tier", "help_usage", "help_flags", "tier"}
+REMOVED_COMMANDS = {"help", "ocr", "ocrdebug", "ocrdiag", "mercy", "shards"}
+ADMIN_COMMANDS = {
+    "build", "checksheet", "configstatus", "digest", "env", "findach",
+    "flushpraise", "health", "listach", "reboot", "reload", "reloadconfig",
+    "testach", "testconfig", "testlevel",
+}
+MONOLITH_ADMIN_COMMANDS = {
+    "configstatus", "findach", "flushpraise", "listach", "reloadconfig",
+    "testach", "testconfig", "testlevel",
+}
+OPS_COMMANDS = {
+    "health": "health_cmd",
+    "digest": "digest_cmd",
+    "reload": "reload_cmd",
+    "checksheet": "checksheet_cmd",
+    "env": "env_cmd",
+    "build": "build_cmd",
+    "reboot": "reboot_cmd",
+}
 
 
 def assert_metadata(command, access_tier=None):
@@ -17,62 +37,74 @@ def assert_metadata(command, access_tier=None):
         assert command.extras["tier"] == access_tier
 
 
-def test_monolith_registered_commands_have_metadata_and_help_remains():
+def test_monolith_removed_commands_are_not_registered_and_remaining_commands_have_metadata():
     app = importlib.import_module("c1c_claims_appreciation")
     names = {command.name for command in app.bot.commands}
+    walked = {command.name for command in app.bot.walk_commands()}
 
-    expected = {
-        "help", "testconfig", "configstatus", "reloadconfig", "listach",
-        "findach", "testach", "testlevel", "flushpraise", "ping",
-    }
+    assert not (REMOVED_COMMANDS & names)
+    assert not (REMOVED_COMMANDS & walked)
+
+    expected = MONOLITH_ADMIN_COMMANDS | {"ping", "helpseed"}
     assert expected.issubset(names)
-    assert "helpseed" in names
 
-    for command in app.bot.commands:
-        if command.name in expected:
-            assert_metadata(command)
+    for name in MONOLITH_ADMIN_COMMANDS:
+        command = app.bot.get_command(name)
+        assert_metadata(command, "admin")
+        assert command.extras["help_usage"]
+        assert command.brief
+        assert command.help
+        assert command.help != command.brief
 
-    assert_metadata(app.bot.get_command("help"), "user")
-    assert_metadata(app.bot.get_command("ping"), "user")
+    assert_metadata(app.bot.get_command("ping"), "staff")
     assert app.bot.get_command("ping").extras["function_group"] == "operational"
     assert app.bot.get_command("ping").extras["help_section"] == "members"
-    assert app.bot.get_command("help").extras["help_flags"] == ("local_help", "transitional")
+    assert app.bot.get_command("ping").extras["help_usage"] == "!ping"
+    assert app.bot.get_command("ping").brief
+    assert app.bot.get_command("ping").help
     assert_metadata(app.bot.get_command("helpseed"), "hidden")
     assert app.bot.get_command("helpseed").extras["help_flags"] == ("hidden", "maintenance")
+    assert app.bot.get_command("helpseed").help
 
 
-def test_admin_staff_monolith_commands_keep_runtime_staff_checks():
+def test_admin_staff_monolith_commands_keep_runtime_admin_checks_and_ping_staff_check():
     app = importlib.import_module("c1c_claims_appreciation")
-    staff_commands = ["testconfig", "configstatus", "reloadconfig", "listach", "findach", "testach", "testlevel", "flushpraise"]
-    for name in staff_commands:
+    for name in MONOLITH_ADMIN_COMMANDS:
         cmd = app.bot.get_command(name)
-        assert_metadata(cmd, "staff")
+        assert_metadata(cmd, "admin")
         names = set(cmd.callback.__code__.co_names)
-        assert "_is_staff" in names
+        assert "_is_admin" in names
+        assert "_is_staff" not in names
+
+    ping = app.bot.get_command("ping")
+    assert_metadata(ping, "staff")
+    assert "_is_staff" in set(ping.callback.__code__.co_names)
 
 
-def test_cog_command_objects_have_metadata_aliases_and_hidden_diagnostics():
+def test_cog_command_objects_have_admin_metadata_aliases_and_descriptions():
     ops = importlib.import_module("cogs.ops")
-    shards = importlib.import_module("cogs.shards.cog")
-
-    ops_commands = {
-        "health": ops.OpsCog.health_cmd,
-        "digest": ops.OpsCog.digest_cmd,
-        "reload": ops.OpsCog.reload_cmd,
-        "checksheet": ops.OpsCog.checksheet_cmd,
-        "env": ops.OpsCog.env_cmd,
-        "build": ops.OpsCog.build_cmd,
-        "reboot": ops.OpsCog.reboot_cmd,
-    }
-    for command in ops_commands.values():
-        assert_metadata(command, "staff")
+    for attr in OPS_COMMANDS.values():
+        command = getattr(ops.OpsCog, attr)
+        assert_metadata(command, "admin")
+        assert command.extras["help_usage"]
+        assert command.brief
+        assert command.help
+        assert command.help != command.brief
     assert ops.OpsCog.reboot_cmd.aliases == ["restart", "rb"]
 
-    assert_metadata(shards.ShardsCog.ocr_debug_cmd, "hidden")
-    assert_metadata(shards.ShardsCog.ocr_diag_cmd, "hidden")
-    assert_metadata(shards.ShardsCog.ocr_cmd, "staff")
-    assert_metadata(shards.ShardsCog.shards_cmd, "user")
-    assert_metadata(shards.ShardsCog.mercy_cmd, "user")
+
+def test_helpseed_export_skips_removed_commands_and_itself():
+    app = importlib.import_module("c1c_claims_appreciation")
+    rows, skipped, _ = collect_help_rows(app.bot)
+    exported = {row["command_key"] for row, _manual in rows}
+    skipped_keys = {key for key, _reason in skipped}
+
+    assert not (REMOVED_COMMANDS & exported)
+    assert "helpseed" not in exported
+    assert "helpseed" in skipped_keys
+    assert "ping" in exported
+    for name in MONOLITH_ADMIN_COMMANDS:
+        assert name in exported
 
 
 def test_help_only_topics_do_not_create_fake_commands():
@@ -83,3 +115,38 @@ def test_help_only_topics_do_not_create_fake_commands():
     assert "claims" not in runnable
     assert "gk" not in runnable
     assert "helpseed" in runnable
+
+class _Perms:
+    def __init__(self, *, administrator=False, manage_guild=False):
+        self.administrator = administrator
+        self.manage_guild = manage_guild
+
+
+class _Role:
+    def __init__(self, role_id):
+        self.id = role_id
+
+
+class _Member:
+    def __init__(self, *, administrator=False, manage_guild=False, roles=()):
+        self.guild_permissions = _Perms(administrator=administrator, manage_guild=manage_guild)
+        self.roles = list(roles)
+
+
+def test_runtime_permission_helpers_distinguish_admin_staff_and_normal_users():
+    app = importlib.import_module("c1c_claims_appreciation")
+    app.CFG["guardian_knights_role_id"] = 42
+
+    normal = _Member()
+    staff = _Member(roles=[_Role(42)])
+    admin = _Member(administrator=True)
+    manager = _Member(manage_guild=True)
+
+    assert not app._is_admin(normal)
+    assert not app._is_staff(normal)
+    assert not app._is_admin(staff)
+    assert app._is_staff(staff)
+    assert app._is_admin(admin)
+    assert app._is_staff(admin)
+    assert app._is_admin(manager)
+    assert app._is_staff(manager)

--- a/tests/test_help_seed.py
+++ b/tests/test_help_seed.py
@@ -135,21 +135,47 @@ def test_access_levels_allowed_and_invalid_blanks():
     assert row["access_level"] == ""
     assert "access_level" in manual
 
-def test_existing_rows_update_without_overwriting_manual_fields():
-    b = bot_with(cmd("ping", usage="!ping"))
-    ws = WS([HEADERS, ["TRUE","achievements","ping","old","old usage","manual cat","staff","manual summary","manual details","note","7"]])
+def test_existing_rows_update_bot_owned_fields_without_overwriting_manual_fields():
+    b = bot_with(cmd("ping", access="admin", usage="!ping --new", section="generated cat"))
+    ws = WS([HEADERS, ["TRUE","achievements","ping","old command","old usage","manual cat","staff","manual summary","manual details","note","7"]])
     result = seed_help_commands(b, ws)
     assert result.updated == 1 and result.created == 0
     updated = ws.batch_calls[0][0][0]["values"][0]
+
+    # Manually curated fields are preserved on existing rows.
     assert updated[0] == "TRUE"
-    assert updated[3] == "!ping"
-    assert updated[4] == "!ping"
     assert updated[5] == "manual cat"
-    assert updated[6] == "user"
     assert updated[7] == "manual summary"
     assert updated[8] == "manual details"
     assert updated[9] == "note"
     assert updated[10] == "7"
+
+    # Bot-owned fields still refresh from command metadata.
+    assert updated[1] == "achievements"
+    assert updated[2] == "ping"
+    assert updated[3] == "!ping"
+    assert updated[4] == "!ping --new"
+    assert updated[6] == "admin"
+
+
+def test_existing_blank_category_summary_and_details_are_filled_from_metadata():
+    b = bot_with(cmd("ping", access="staff", usage="!ping", section="members"))
+    ws = WS([HEADERS, ["TRUE","achievements","ping","old command","old usage","   ","user",""," 	 ","note","7"]])
+    result = seed_help_commands(b, ws)
+    assert result.updated == 1 and result.created == 0
+    updated = ws.batch_calls[0][0][0]["values"][0]
+
+    assert updated[5] == "members"
+    assert updated[7] == "ping brief"
+    assert updated[8] == "ping help"
+    assert updated[0] == "TRUE"
+    assert updated[9] == "note"
+    assert updated[10] == "7"
+    assert updated[1] == "achievements"
+    assert updated[2] == "ping"
+    assert updated[3] == "!ping"
+    assert updated[4] == "!ping"
+    assert updated[6] == "staff"
 
 def test_new_rows_created_with_false_bot_key_and_blank_sort_order():
     b = bot_with(cmd("ping"))
@@ -219,8 +245,7 @@ def test_seed_command_staff_guard_and_help_behavior_unchanged():
     assert seed is not None
     assert seed.extras["tier"] == "hidden"
     assert "_is_staff" in seed.callback.__code__.co_names
-    assert app.bot.get_command("help") is not None
-    assert app.bot.get_command("help").extras["help_flags"] == ("local_help", "transitional")
+    assert app.bot.get_command("help") is None
 
 def test_reply_format_includes_manual_counts_and_local_help_only():
     r = seed_help_commands(bot_with(cmd("ping")), WS([HEADERS]))


### PR DESCRIPTION
### Motivation
- Normalize runtime permission checks so server-administrator operations use explicit guild-admin permissions while staff (Guardian Knights) remain a separate role concept.
- Stop registering a local `!help` command inside Achievements so shared/global help is owned elsewhere and remove Achievements-local command surface (Shards/Mercy/OCR) from startup.
- Make help-seed exports more robust by treating whitespace-only category/summary/details as empty and add explicit human-friendly `brief`/`help` text for documented commands.

### Description
- Introduced `def _is_admin(member: discord.Member)` and changed command runtime guards to call `_is_admin` for admin-only operations, keeping `_is_staff` for role-based staff checks; updated many command access checks accordingly in `c1c_claims_appreciation.py` and `cogs/ops.py`.
- Removed registration of the local `!help` implementation and removed loading/comments around Shards/Mercy/OCR from Achievements startup in `c1c_claims_appreciation.py` so Achievements is silent about help topics that are handled elsewhere.
- Hardened help-seed blank-field detection in `achievements/help_seed.py` by treating whitespace-only cells as empty via `if not str(new[col[h]] or "").strip():` so blank category/summary/details get filled from metadata.
- Added `_document_command` and `_document_ops_command` helpers that set `command.brief` and `command.help` for exported commands and applied rich descriptions to many commands; updated help metadata `access_tier`/`tier` annotations from `staff` to `admin` where appropriate.
- Tests updated to reflect removed commands and new permission semantics: updated and extended `tests/test_command_metadata_annotations.py` and `tests/test_help_seed.py` to assert removal of local commands, admin-tier metadata, recorded documentation strings, and the new `help_seed` export behavior.

### Testing
- Ran the unit test suite with `pytest` covering `tests/test_command_metadata_annotations.py` and `tests/test_help_seed.py` (and related tests); the updated tests exercise command registration, metadata, help-seed export logic, and runtime permission helpers, and they passed.
- Exercised `seed_help_commands` unit tests to validate updates vs fills behavior, blank-field filling, append/fill batching, and helpful error messages for missing capabilities; assertions succeeded.
- Verified Cog-based command metadata and descriptions via tests that instantiate `cogs.ops` and introspect `OpsCog` command objects; assertions for `brief`/`help`, aliases, and changed access tiers succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ba1b784d883239c7c622a4bd4fc62)