### PR TITLE
Add emoji fallback for praise thumbnails and tests

### DIFF
--- a/c1c_claims_appreciation.py
+++ b/c1c_claims_appreciation.py
@@ -547,6 +547,70 @@ def _category_by_key(cat_key: str) -> Optional[dict]:
     return None
 
 EMOJI_TAG_RE = re.compile(r"^<a?:\w+:\d+>$")
+CUSTOM_EMOJI_ID_RE = re.compile(r"^<a?:\w+:(\d+)>$")
+
+
+def _emoji_asset_url(emoji) -> Optional[str]:
+    try:
+        url = getattr(emoji, "url", None)
+        return str(url) if url else None
+    except Exception:
+        return None
+
+
+def _find_custom_emoji(emoji_id: int, *, bot=None, guild=None):
+    if bot is not None:
+        try:
+            emoji = bot.get_emoji(emoji_id)
+            if emoji is not None:
+                return emoji
+        except Exception:
+            pass
+    if guild is not None:
+        try:
+            return discord.utils.get(getattr(guild, "emojis", []) or [], id=emoji_id)
+        except Exception:
+            return None
+    return None
+
+
+def resolve_praise_thumbnail_url(role: discord.Role, emoji_name_or_id: Optional[str], bot=None, guild: discord.Guild | None = None) -> Optional[str]:
+    """Resolve the praise thumbnail without blocking praise creation on bad emoji config.
+
+    Role icons keep priority. EmojiNameOrId is only used as a custom-emoji fallback
+    when no role icon/display icon is available.
+    """
+    role_icon = _big_role_icon_url(role)
+    if role_icon:
+        return role_icon
+
+    value = _to_str(emoji_name_or_id).strip()
+    if not value:
+        return None
+
+    emoji_id: int | None = None
+    mention = CUSTOM_EMOJI_ID_RE.match(value)
+    if mention:
+        try:
+            emoji_id = int(mention.group(1))
+        except Exception:
+            emoji_id = None
+    elif value.isdigit():
+        try:
+            emoji_id = int(value)
+        except Exception:
+            emoji_id = None
+
+    try:
+        if emoji_id is not None:
+            return _emoji_asset_url(_find_custom_emoji(emoji_id, bot=bot, guild=guild))
+
+        if guild is not None:
+            emoji = discord.utils.get(getattr(guild, "emojis", []) or [], name=value)
+            return _emoji_asset_url(emoji)
+    except Exception:
+        return None
+    return None
 
 def resolve_emoji_text(guild: discord.Guild, value: Optional[str], fallback: Optional[str]=None) -> str:
     v = _to_str(value).strip()
@@ -672,9 +736,11 @@ def build_achievement_embed(guild: discord.Guild, user: discord.Member, role: di
         if ficon: emb.set_footer(text=footer_text, icon_url=ficon)
         else:     emb.set_footer(text=footer_text)
 
-    hero = resolve_hero_image(guild, role, ach_row)
-    if hero:
-        emb.set_thumbnail(url=hero)  # top-right
+    thumb = resolve_hero_image(guild, role, ach_row) or resolve_praise_thumbnail_url(
+        role, ach_row.get("EmojiNameOrId"), guild=guild
+    )
+    if thumb:
+        emb.set_thumbnail(url=thumb)  # top-right
     return emb
 
 def build_group_embed(guild: discord.Guild, user: discord.Member, items: List[Tuple[discord.Role, dict]]) -> discord.Embed:
@@ -695,9 +761,11 @@ def build_group_embed(guild: discord.Guild, user: discord.Member, items: List[Tu
         lines.append(f"• {body}")
     emb.description = "\n".join(lines)
 
-    hero = resolve_hero_image(guild, r0, a0)
-    if hero:
-        emb.set_thumbnail(url=hero)  # top-right
+    thumb = resolve_hero_image(guild, r0, a0) or resolve_praise_thumbnail_url(
+        r0, a0.get("EmojiNameOrId"), guild=guild
+    )
+    if thumb:
+        emb.set_thumbnail(url=thumb)  # top-right
     footer_text = CFG.get("embed_footer_text")
     if footer_text:
         ficon = _safe_icon(CFG.get("embed_footer_icon"))

--- a/tests/test_praise_thumbnail.py
+++ b/tests/test_praise_thumbnail.py
@@ -1,0 +1,135 @@
+import discord
+
+import c1c_claims_appreciation as app
+
+
+class FakeAsset:
+    def __init__(self, url):
+        self.url = url
+
+    def with_size(self, size):
+        return FakeAsset(f"{self.url}?size={size}")
+
+
+class FakeEmoji:
+    def __init__(self, emoji_id, name="sparkle", url="https://cdn.example/emoji.png", animated=False):
+        self.id = emoji_id
+        self.name = name
+        self.url = url
+        self.animated = animated
+
+
+class FakeRole:
+    def __init__(self, *, icon_url=None, color=None, name="Achievement Role"):
+        self.name = name
+        self.display_icon = FakeAsset(icon_url) if icon_url else None
+        self.icon = None
+        self.color = color or discord.Color.default()
+
+
+class FakeGuild:
+    def __init__(self, emojis=()):
+        self.emojis = list(emojis)
+
+
+class FakeUser:
+    display_name = "Tester"
+    mention = "<@123>"
+
+
+def _row(emoji_value, **overrides):
+    row = {
+        "EmojiNameOrId": emoji_value,
+        "Title": "Great job, {user}!",
+        "Body": "Unlocked {role} {emoji}",
+        "Footer": "Footer {role}",
+        "ColorHex": "#123456",
+    }
+    row.update(overrides)
+    return row
+
+
+def _embed_dict(embed):
+    return embed.to_dict()
+
+
+def test_role_icon_wins_over_emoji_fallback():
+    emoji = FakeEmoji(152503451646828746, url="https://cdn.example/emoji.png")
+    guild = FakeGuild([emoji])
+    role = FakeRole(icon_url="https://cdn.example/role.png")
+
+    assert app.resolve_praise_thumbnail_url(role, str(emoji.id), guild=guild) == "https://cdn.example/role.png?size=512"
+
+    embed = app.build_achievement_embed(guild, FakeUser(), role, _row(str(emoji.id)))
+    assert _embed_dict(embed)["thumbnail"]["url"] == "https://cdn.example/role.png?size=512"
+
+
+def test_existing_hero_thumbnail_wins_over_emoji_fallback():
+    emoji = FakeEmoji(152503451646828746, url="https://cdn.example/emoji.png")
+    guild = FakeGuild([emoji])
+    role = FakeRole()
+
+    embed = app.build_achievement_embed(
+        guild,
+        FakeUser(),
+        role,
+        _row(str(emoji.id), HeroImageURL="https://cdn.example/hero.png"),
+    )
+
+    assert _embed_dict(embed)["thumbnail"]["url"] == "https://cdn.example/hero.png"
+
+
+def test_numeric_emoji_id_resolves_to_thumbnail_when_role_has_no_icon():
+    emoji = FakeEmoji(152503451646828746, url="https://cdn.example/numeric.png")
+    guild = FakeGuild([emoji])
+    role = FakeRole()
+
+    embed = app.build_achievement_embed(guild, FakeUser(), role, _row("152503451646828746"))
+
+    assert _embed_dict(embed)["thumbnail"]["url"] == "https://cdn.example/numeric.png"
+
+
+def test_custom_emoji_mention_resolves_to_thumbnail_when_role_has_no_icon():
+    emoji = FakeEmoji(152503451646828746, url="https://cdn.example/mention.png")
+    guild = FakeGuild([emoji])
+    role = FakeRole()
+
+    embed = app.build_achievement_embed(guild, FakeUser(), role, _row("<:sparkle:152503451646828746>"))
+
+    assert _embed_dict(embed)["thumbnail"]["url"] == "https://cdn.example/mention.png"
+
+
+def test_group_embed_uses_guild_only_emoji_fallback_without_global_bot(monkeypatch):
+    emoji = FakeEmoji(152503451646828746, url="https://cdn.example/group.png")
+    guild = FakeGuild([emoji])
+    role = FakeRole()
+    monkeypatch.delattr(app, "bot", raising=False)
+
+    embed = app.build_group_embed(guild, FakeUser(), [(role, _row(str(emoji.id)))])
+
+    assert _embed_dict(embed)["thumbnail"]["url"] == "https://cdn.example/group.png"
+
+
+def test_invalid_or_unresolved_emoji_does_not_set_thumbnail_or_block_embed():
+    guild = FakeGuild([])
+    role = FakeRole()
+
+    for value in ("", "not-a-real-emoji", "😀", "999999999"):
+        embed = app.build_achievement_embed(guild, FakeUser(), role, _row(value))
+        data = _embed_dict(embed)
+        assert "thumbnail" not in data
+        assert data["title"] == "Great job, <@123>!"
+
+
+def test_existing_title_body_footer_and_color_behavior_remains_unchanged():
+    emoji = FakeEmoji(152503451646828746, name="sparkle", url="https://cdn.example/emoji.png")
+    guild = FakeGuild([emoji])
+    role = FakeRole(name="Helper")
+
+    embed = app.build_achievement_embed(guild, FakeUser(), role, _row(str(emoji.id)))
+    data = _embed_dict(embed)
+
+    assert data["title"] == "Great job, <@123>!"
+    assert data["description"] == "Unlocked Helper <:sparkle:152503451646828746>"
+    assert data["footer"]["text"] == "Footer Helper"
+    assert data["color"] == int("123456", 16)


### PR DESCRIPTION
### Motivation
- Ensure praise embeds can use a custom-emoji image as a thumbnail fallback when a role has no icon so praise creation doesn't fail or omit thumbnails.

### Description
- Add `CUSTOM_EMOJI_ID_RE` and helpers `_emoji_asset_url` and `_find_custom_emoji` to safely obtain emoji asset URLs.
- Implement `resolve_praise_thumbnail_url(role, emoji_name_or_id, bot=None, guild=None)` which prefers role display/icon then resolves emoji by mention, numeric id, or name via bot or guild.
- Update `build_achievement_embed` and `build_group_embed` to use `resolve_praise_thumbnail_url` as a fallback to `resolve_hero_image` when selecting the embed thumbnail.
- Add unit tests in `tests/test_praise_thumbnail.py` covering role-icon priority, hero-image priority, numeric and mention emoji resolution, group-embed behavior without a global bot, invalid emoji handling, and existing embed content behavior.

### Testing
- Added `tests/test_praise_thumbnail.py` and ran `pytest tests/test_praise_thumbnail.py` locally, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53e67b617083239d97a3e34a5dc275)